### PR TITLE
Allow to return the component itself

### DIFF
--- a/addon/components/html-select.js
+++ b/addon/components/html-select.js
@@ -16,9 +16,13 @@ export default Ember.Component.extend({
     this.selectedValue = Ember.computed('mainComponent.model.' + this.get('mainComponent.property'), function() {
       const propertyIsModel = this.get('mainComponent.propertyIsModel');
       var value = this.get('mainComponent.model.' + this.get('mainComponent.property'));
-      if(propertyIsModel) {
+      if(propertyIsModel && value != null) {
         const optionValuePath = this.get('mainComponent.optionValuePath');
-        value = value.get(optionValuePath);
+        if(value.get === undefined) {
+          value = value[optionValuePath];
+        } else {
+          value = value.get(optionValuePath);
+        }
       }
       return value;
     });

--- a/addon/components/html-select.js
+++ b/addon/components/html-select.js
@@ -3,7 +3,7 @@ import layout from '../templates/components/html-select';
 
 export default Ember.Component.extend({
   layout: layout,
-  
+
   didReceiveAttrs(/*attrs*/) {
     this._super(...arguments);
     var content = this.get('content');
@@ -14,13 +14,19 @@ export default Ember.Component.extend({
     }
     // set it to the correct value of the selection
     this.selectedValue = Ember.computed('mainComponent.model.' + this.get('mainComponent.property'), function() {
-      return this.get('mainComponent.model.' + this.get('mainComponent.property'));
+      const propertyIsModel = this.get('mainComponent.propertyIsModel');
+      var value = this.get('mainComponent.model.' + this.get('mainComponent.property'));
+      if(propertyIsModel) {
+        const optionValuePath = this.get('mainComponent.optionValuePath');
+        value = value.get(optionValuePath);
+      }
+      return value;
     });
   },
 
   actions: {
     change() {
-      
+
       const selectedEl = this.$('select')[0];
       let selectedIndex = selectedEl.selectedIndex;
       // check whether we show prompt the the correct to show index is one less
@@ -34,8 +40,17 @@ export default Ember.Component.extend({
         }
       }
       const content = this.get('mainComponent.content');
-      const selectedValue = content[selectedIndex];
-      const selectedID = selectedValue[this.get('mainComponent.optionValuePath')];
+      const selectedValue = content.objectAt(selectedIndex);
+      const optionValuePath = this.get('mainComponent.optionValuePath');
+      const propertyIsModel = this.get('mainComponent.propertyIsModel');
+      var selectedID;
+
+      if(propertyIsModel) {
+        selectedID = selectedValue;
+      } else  {
+        selectedID = selectedValue[optionValuePath];
+      }
+
       this.set('mainComponent.model.' + this.get('mainComponent.property'), selectedID);
       const changeAction = this.get('action');
       if(changeAction){

--- a/tests/unit/components/em-select-test.js
+++ b/tests/unit/components/em-select-test.js
@@ -101,6 +101,29 @@ test('em-select can select an item', function(assert) {
 
 });
 
+test('em-select can select the model itself', function(assert) {
+
+  this.set('fruitOptions', fruitOptions);
+  this.set('fruitSalad', fruitSalad);
+
+  this.render(hbs `{{em-select label="Fruits:" content=fruitOptions propertyIsModel=true optionLabelPath='name' prompt='None' property='favoriteFruit' model=fruitSalad}}`);
+
+  var element = this.$();
+  assert.equal(element.find('label:contains("Fruits:")').length, 1, 'label has for property');
+
+  var select = element.find('select')[0];
+  assert.ok(select.options.length > 3, 'select has options');
+
+  Ember.run(() => {
+    this.$(select).val('3');
+    this.$(select).trigger('change');
+  });
+
+  assert.equal(fruitSalad.get('favoriteFruit.id'), 3, 'model favorite fruit is the selection');
+  assert.equal(fruitSalad.get('favoriteFruit.name'), 'Orange', 'model favorite fruit is the selection');
+
+});
+
 test('Textarea renders with custom css', function(assert) {
   this.render(hbs`{{em-select elementClass="col-md-6"}}`);
 


### PR DESCRIPTION
The issue is related to #68 

It allow to do :

    {{em-select label="Course" property="course" content=courses canShowErrors=true prompt=" " propertyIsModel=true optionLabelPath="name"}}

`propertyIsModel` allow to assign the model as value.
