### PR TITLE
fix undefined error on submit validate

### DIFF
--- a/addon/components/em-form.js
+++ b/addon/components/em-form.js
@@ -73,7 +73,7 @@ export default Ember.Component.extend({
             return _this.sendAction();
           }
         };
-      })(this));
+      })(this)).catch(function(){});
     }
   }
 });


### PR DESCRIPTION
This fixes the "undefined" error logging issue when a call to validate is made.

When internal validations state is false on the form model, and a submit action is called on the form it will produce this error.
Even though the correct behavior should be to allow to submit only when the form is valid (thereby enabling the submit button), it's probably still better to catch this error instead of having it propagate and display in console.

Reference to this issue related to ember-validations can be found here:

https://github.com/dockyard/ember-validations/issues/377