### PR TITLE
Adding optionality for optgroups in em-select

### DIFF
--- a/addon/templates/components/html-select.hbs
+++ b/addon/templates/components/html-select.hbs
@@ -1,12 +1,26 @@
 <select {{action 'change' on='change'}} class="form-control {{mainComponent.elementClass}}" id={{mainComponent.id}}>
-{{#if mainComponent.prompt}}
-  <option value="null" selected={{eq null selectedValue}}>
-    {{mainComponent.prompt}}
-  </option>
-{{/if}}
-{{#each (get mainComponent "content") key="@index" as |item|}}
-  <option value="{{get item mainComponent.optionValuePath}}" selected={{eq (get item mainComponent.optionValuePath) selectedValue}}>
-    {{get item mainComponent.optionLabelPath}}
-  </option>
-  {{/each}}
+    {{#if mainComponent.prompt}}
+        <option value="null" selected={{eq null selectedValue}}>
+            {{mainComponent.prompt}}
+        </option>
+    {{/if}}
+    {{#if mainComponent.optionGroupContentPath}}
+        {{#each (get mainComponent "content") key="@index" as |group|}}
+            <optgroup label="{{get group mainComponent.optionGroupLabelPath}}">
+                {{#each (get group mainComponent.optionGroupContentPath) key="@index" as |item|}}
+                    <option value="{{get item mainComponent.optionValuePath}}"
+                            selected={{eq (get item mainComponent.optionValuePath) selectedValue}}>
+                        {{get item mainComponent.optionLabelPath}}
+                    </option>
+                {{/each}}
+            </optgroup>
+        {{/each}}
+    {{else}}
+        {{#each (get mainComponent "content") key="@index" as |item|}}
+            <option value="{{get item mainComponent.optionValuePath}}"
+                    selected={{eq (get item mainComponent.optionValuePath) selectedValue}}>
+                {{get item mainComponent.optionLabelPath}}
+            </option>
+        {{/each}}
+    {{/if}}
 </select>


### PR DESCRIPTION
(This is my first PR so bear with me and let me know if I did something wrong :S)

Will use the passed in `content` props as the object holding the grouping data, and then look for the actual selectable options on `optionGroupContentPath`. The `optionValuePath` and `optionLabelPath` props remain the valid options for the final selectable options.

Example: 

Model 1:

```
-- category.js
name: DS.attr('string'),
statuses: DS.hasMany('status')
```

Model 2:

```
-- status.js
name: DS.attr('string'),
category: DS.belongsTo('category')
```

Template:

```
{{em-select
label="Statuses"
property="status"
content=model.categories
optionValuePath="id"
optionLabelPath="name"
optionGroupLabelPath="name"
optionGroupContentPath="statuses"
prompt="Select a category.."}}
```
