### PR TITLE
Add a custom input component

### DIFF
--- a/addon/components/em-custom-input.js
+++ b/addon/components/em-custom-input.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+import FormGroupComponent from './em-form-group';
+
+/*
+Form Input
+
+Syntax:
+{{#em-custom-input property="property name"}}Something{{/em-custom-input}}
+ */
+export default FormGroupComponent.extend({
+  elementClass: null,
+  htmlComponent: 'erf-html-custom-input',
+  property: null,
+  label: null,
+  name: null,
+  placeholder: null,
+  required: null,
+  autofocus: null,
+  disabled: null,
+  controlWrapper: Ember.computed('form.formLayout', {
+    get: function() {
+      if (this.get('form.formLayout') === 'horizontal') {
+        return 'col-sm-10';
+      }
+      return null;
+    }
+  })
+});

--- a/addon/components/html-custom-input.js
+++ b/addon/components/html-custom-input.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import layout from '../templates/components/html-input';
+
+export default Ember.Component.extend({
+  layout: layout,
+  didReceiveAttrs( /*attrs*/ ) {
+    this._super(...arguments);
+    // set it to the correct value of the selection
+    this.selectedValue = Ember.computed.alias('mainComponent.model.' + this.get('mainComponent.property'));
+  }
+});

--- a/addon/templates/components/em-form-group.hbs
+++ b/addon/templates/components/em-form-group.hbs
@@ -1,21 +1,13 @@
 {{#if wrapperClass}}
     <div class={{wrapperClass}}>
-      {{#unless hasBlock}}
         {{form-group label=label yieldInLabel=yieldInLabel
           labelWrapperClass=labelWrapperClass labelClass=labelClass
           help=help shouldShowErrors=shouldShowErrors controlWrapper=controlWrapper
           cid=cid validationIcons=validationIcons mainComponent=this form=form}}
-      {{else}}
-        {{yield}}
-      {{/unless}}
     </div>
 {{else}}
-  {{#unless hasBlock}}
     {{form-group label=label yieldInLabel=yieldInLabel
       labelWrapperClass=labelWrapperClass labelClass=labelClass
       help=help shouldShowErrors=shouldShowErrors controlWrapper=controlWrapper
       cid=cid validationIcons=validationIcons mainComponent=this form=form}}
-  {{else}}
-    {{yield}}
-  {{/unless}}
 {{/if}}

--- a/app/components/em-custom-input.js
+++ b/app/components/em-custom-input.js
@@ -1,0 +1,3 @@
+import InputComponent from 'ember-rapid-forms/components/em-custom-input';
+
+export default InputComponent;

--- a/app/components/erf-html-custom-input.js
+++ b/app/components/erf-html-custom-input.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-rapid-forms/components/html-custom-input';

--- a/tests/dummy/app/templates/controls/wrapped-input.hbs
+++ b/tests/dummy/app/templates/controls/wrapped-input.hbs
@@ -9,6 +9,9 @@ This gives you the freedom to support extra visual effects when neccessary.
 \{{#em-form model=model formLayout=layout}}
     \{{em-input label="Name" property="name"}}
     \{{my-custom-input label="Name" property="name"}}
+    \{{#em-custom-input label="Password" property="password"}}
+        \{{input value=model.password type="password"}}
+    \{{/em-custom-input}}
 \{{/em-form}}
     </code></pre>
 </div>
@@ -42,5 +45,8 @@ WrappedInputComponent = Em.Component.extend({
 {{#em-form model=model formLayout=layout}}
     {{em-input label="Name" property="name"}}
     {{my-custom-input label="Name" property="name"}}
+    {{#em-custom-input label="Password" property="password"}}
+        {{input value=model.password type="password"}}
+    {{/em-custom-input}}
 {{/em-form}}
 </div>

--- a/tests/unit/components/em-custom-input-test.js
+++ b/tests/unit/components/em-custom-input-test.js
@@ -1,0 +1,39 @@
+import {
+  moduleForComponent,
+  test
+  } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('em-custom-input', {
+  // Specify the other units that are required for this test
+  integration: true
+});
+
+test('Input gets rendered', function(assert) {
+
+  this.render(hbs`{{#em-custom-input}}{{inupt}}{{/em-custom-input}}`);
+
+  assert.equal(this.$().find('input').length, 1, 'Input is rendered correctly');
+});
+
+test('Input renders with custom css', function(assert) {
+  this.render(hbs`{{#em-custom-input label='My label' elementClass="col-md-6" controlWrapper="col-md-6" labelClass="col-md-4"}}{{input}}{{/em-custom-input}}`);
+
+  assert.ok(this.$().find('label').hasClass('col-md-4'), 'Label has correct class');
+  assert.ok(this.$().find('input').parent().parent().hasClass('col-md-6'), 'Input parent has correct class');
+  assert.ok(this.$().find('input').hasClass('col-md-6'), 'Input has correct class');
+});
+
+test('cid correctly sets the id for the input and it\'s label', function(assert) {
+  this.render(hbs`{{#em-custom-input label='some label' cid='test-cid'}}{{inupt id=cid}}{{/em-custom-input}}`);
+
+  assert.equal(this.$('input').attr('id'), 'test-cid', 'input has correct id');
+  assert.equal(this.$('label').attr('for'), 'test-cid', 'label has correct \'for\'');
+});
+
+test('cid is property by default', function(assert) {
+  this.render(hbs`{{#em-custom-input label='some label' property='test-cid'}}{{inupt id=cid}}{{/em-custom-input}}`);
+
+  assert.equal(this.$('input').attr('id'), 'test-cid', 'input has correct id');
+  assert.equal(this.$('label').attr('for'), 'test-cid', 'label has correct \'for\'');
+});


### PR DESCRIPTION
This PR allow to do this : 

    {{#em-custom-input label="Password" property="password"}}
        {{input value=model.password type="password"}}
    {{/em-custom-input}}

Useful for complex input like a WYSIWYG editor or a select2 input. It keeps the labels, errors and other options.

The code is not really DRY but I think the whole project needs refactoring. It should be possible to remove `app/components/erf-html-custom-input.js` and `app/components/em-custom-input.js`. This is for another PR.