### PR TITLE
Added ability to show/hide errors for computed values

### DIFF
--- a/addon/mixins/input-errors.js
+++ b/addon/mixins/input-errors.js
@@ -18,5 +18,10 @@ export default Ember.Mixin.create({
     this.eachRelationship((key) => {
       this.set(`visibleErrors.${key}`, visible);
     });
+    Object.keys(this.get('dependentValidationKeys')).forEach((key) => {
+      if (key.indexOf('.') === -1) {
+        this.set(`visibleErrors.${key}`, visible);
+      }
+    });
   }
 });

--- a/tests/dummy/app/models/simple_person.js
+++ b/tests/dummy/app/models/simple_person.js
@@ -4,28 +4,48 @@ import EV from 'ember-validations';
 import InputErrors from 'ember-rapid-forms/mixins/input-errors';
 
 var SimplePerson = DS.Model.extend(EV, InputErrors, {
-  name: DS.attr('string'),
+  firstName: DS.attr('string', { defaultValue: null }),
+  lastName: DS.attr('string', { defaultValue: null }),
   password: DS.attr('string'),
   comment: DS.attr('string'),
   active: DS.attr('boolean'),
   gender: DS.attr('string'),
-  nameHasValue: Ember.computed('name', {
+  nameHasValue: Ember.computed('fullName', {
     get: function() {
-      return !!this.get('name');
+      return !!this.get('fullName');
     }
   }),
 
-  asjson: Ember.computed('name', 'password', 'comment', 'active', 'gender', function() {
-    return "name: " + (this.get('name')) + ", password: " + (this.get('password')) + ", comment: " + (this.get('comment')) + ", active: " + (this.get('active')) + ", gender: " + (this.get('gender'));
+  fullName: Ember.computed('firstName', 'lastName', {
+    //jshint unused:false
+    get: function() {
+      if (this.get('firstName')) {
+        return `${this.get('firstName')} ${this.get('lastName')}`;
+      }
+      else {
+        return null;
+      }
+    },
+    set: function(key, value) {
+      let [firstName, lastName] = value.split(/\s+/);
+      firstName = firstName ? firstName : null;
+      lastName = lastName ? lastName : null;
+      this.setProperties({ firstName, lastName });
+      return value;
+    }
+  }),
+
+  asjson: Ember.computed('fullName', 'firstName', 'lastName', 'password', 'comment', 'active', 'gender', function() {
+    return "fullName: " + (this.get('fullName')) + ", firstName: " + (this.get('firstName')) + ", lastName: " + (this.get('lastName')) + ", password: " + (this.get('password')) + ", comment: " + (this.get('comment')) + ", active: " + (this.get('active')) + ", gender: " + (this.get('gender'));
   })
 });
 
 SimplePerson.reopen({
   validations: {
-    name: {
-      presence: true,
-      length: {
-        minimum: 5
+    fullName: {
+      format: {
+        with: /^[^\s]+(\s[^\s]+)+$/,
+        message: "enter a first and last name"
       }
     },
     password: {

--- a/tests/dummy/app/templates/form_sample.hbs
+++ b/tests/dummy/app/templates/form_sample.hbs
@@ -6,7 +6,7 @@
 <hr/>
 
 {{#em-form model=model formLayout=layout}}
-    {{em-input property="name" label="Full Name" placeholder="Enter a name..." canShowErrors=model.visibleErrors.name}}
+    {{em-input property="fullName" label="Full Name" placeholder="Enter a full name..." canShowErrors=model.visibleErrors.fullName}}
     {{em-input property="password" label="Password" placeholder="And password..." type="password" disabled=nameHasValue canShowErrors=model.visibleErrors.password}}
     {{em-text property="comment" label="Comment" placeholder="Comment please.." rows=4 canShowErrors=model.visibleErrors.comment}}
     {{em-select property="gender" label="Gender" prompt="-select-" content=genderOptions optionValuePath="id" optionLabelPath="name" canShowErrors=model.visibleErrors.gender}}

--- a/tests/dummy/app/templates/getstarted.hbs
+++ b/tests/dummy/app/templates/getstarted.hbs
@@ -35,7 +35,8 @@ import EV from 'ember-validations';
 import InputErrors from 'ember-rapid-forms/mixins/input-errors';
 
 var User = DS.Model.extend(EV, InputErrors, {
-    name: DS.attr('string'),
+    firstName: DS.attr('string', { defaultValue: null }),
+    lastName: DS.attr('string', { defaultValue: null }),
     password: DS.attr('string'),
     comment: DS.attr('string'),
     active: DS.attr('boolean'),
@@ -44,16 +45,33 @@ var User = DS.Model.extend(EV, InputErrors, {
         get:function(){
             return !!this.get('name').length;
         }
+    }),
+    fullName: Ember.computed('firstName', 'lastName', {
+        get: function() {
+            if (this.get('firstName')) {
+                return `${this.get('firstName')} ${this.get('lastName')}`;
+            }
+            else {
+                return null;
+            }
+        },
+        set: function(key, value) {
+            let [firstName, lastName] = value.split(/\s+/);
+            firstName = firstName ? firstName : null;
+            lastName = lastName ? lastName : null;
+            this.setProperties({ firstName, lastName });
+            return value;
+        }
     })
 })
 
 
 User.reopen({
     validations: {
-        name: {
-            presence: true,
-            length: {
-                minimum: 5
+        fullName: {
+            format: {
+                with: /^[^\s]+(\s[^\s]+)+$/,
+                message: "enter a first and last name"
             }
         },
         password: {
@@ -79,7 +97,7 @@ User.reopen({
 <div class="well line-example">
     <pre><code class="handlebars">
 \{{#em-form model=model formLayout=layout}}
-    \{{em-input property="name" label="Full Name" placeholder="Enter a name..." canShowErrors=model.visibleErrors.name}}
+    \{{em-input property="fullName" label="Full Name" placeholder="Enter a full name..." canShowErrors=model.visibleErrors.fullName}}
     \{{em-input property="password" label="Password" placeholder="And password..." type="password" disabled=nameHasValue canShowErrors=model.visibleErrors.password}}
     \{{em-text property="comment" label="Comment" placeholder="Comment please.." rows=4 canShowErrors=model.visibleErrors.comment}}
     \{{em-select property="gender" label="Gender" prompt="-select-" content=genderOptions optionValuePath="id" optionLabelPath="name" canShowErrors=model.visibleErrors.gender}}


### PR DESCRIPTION
GCorbel's input_errors (https://github.com/piceaTech/ember-rapid-forms/commit/2f3b092da9328de9f4ebd794f42b5aedee4ff96c) added the ability to manually show/hide validation errors. He did this by iterating through eachAttribute and eachRelationship of a DS.Model object and setting the error visibility.

However, computed values that might appear in a form (such as a fullName) are not included in a DS.Model's attributes or relationships. If a validation exists for the computed value, it is listed in the object's dependentValidationKeys.

To show/hide errors for computed values, I've added an iteration through an object's dependentValidationKeys in function changeErrorsVisibility.