### PR TITLE
Add `required` and `autofocus` attributes to `html-input` component.

### DIFF
--- a/addon/templates/components/html-input.hbs
+++ b/addon/templates/components/html-input.hbs
@@ -1,1 +1,11 @@
-{{input placeholder=mainComponent.placeholder value=selectedValue name=mainComponent.name type=mainComponent.type disabled=mainComponent.disabled class=(concat "form-control " mainComponent.elementClass) id=mainComponent.id}}
+{{input
+  placeholder=mainComponent.placeholder
+  value=selectedValue
+  name=mainComponent.name
+  type=mainComponent.type
+  disabled=mainComponent.disabled
+  class=(concat "form-control " mainComponent.elementClass)
+  id=mainComponent.id
+  required=mainComponent.required
+  autofocus=mainComponent.autofocus
+}}

--- a/tests/dummy/app/templates/controls/input.hbs
+++ b/tests/dummy/app/templates/controls/input.hbs
@@ -24,5 +24,11 @@ Standard <i>&lt;input&gt;</i> tag which is a one-line input field that a user ca
     <tr><td>property</td><td>The property name in the model instance bound to the form</td><td>none, value is required.</td></tr>
     <tr><td>type</td><td>The type of the input</td><td>none, can be <i>password, email</i> or any other browser supported input type</td></tr>
     <tr><td>cid</td><td>If set, the specified identifier will be set as the <i>id</i> attribute of the <i>input</i> tag.</td><td>Ember's default ID</td></tr>
+    <tr><td>name</td><td>The name of the input element.</td><td>null</td></tr>
+    <tr><td>placeholder</td><td>The standard input placeholder.</td><td>null</td></tr>
+    <tr><td>elementClass</td><td>The class of the input element concatenated with the default 'form-control' class.</td><td>form-control</td></tr>
+    <tr><td>disabled</td><td>Standard HTML5 disabled attribute.</td><td>null</td></tr>
+    <tr><td>required</td><td>Standard HTML5 required attribute.</td><td>null</td></tr>
+    <tr><td>autofocus</td><td>Standard HTML5 autofocus attribute.</td><td>null</td></tr>
     <tr><td>onKeyUp</td><td>If true, errors will show as soon as the user types in the field.</td><td>false</td></tr>
 </table>

--- a/tests/unit/components/em-input-test.js
+++ b/tests/unit/components/em-input-test.js
@@ -52,3 +52,17 @@ test('the "for" of the label is the "id" of the input', function(assert) {
 
   assert.equal(this.$('input').attr('id'), this.$('label').attr('for'), 'the "for" of the label is not the "id" of the input');
 });
+
+test('Input can be a required field', function(assert) {
+
+  this.render(hbs`{{em-input required=true}}`);
+
+  assert.ok(this.$().find('input').attr('required'), 'input becomes a required field');
+});
+
+test('Input can be autofocused', function(assert) {
+
+  this.render(hbs`{{em-input autofocus=true}}`);
+
+  assert.ok(this.$().find('input').attr('autofocus'), 'input has autofocus');
+});


### PR DESCRIPTION
The attributes were already present on the component class but not assigned on the template file.