### PR TITLE
Remove duplication in class attribute

### DIFF
--- a/addon/components/em-form-group.js
+++ b/addon/components/em-form-group.js
@@ -30,7 +30,7 @@ export default Ember.Component.extend(InFormMixin, HasPropertyMixin, HasProperty
   tagName: 'div',
   "class": 'form-group',
   layout: layout,
-  classNameBindings: ['class', 'hasSuccess', 'hasWarning', 'hasError', 'validationIcons:has-feedback'],
+  classNameBindings: ['hasSuccess', 'hasWarning', 'hasError', 'validationIcons:has-feedback'],
   attributeBindings: ['disabled'],
   canShowErrors: false,
   hasSuccess: Ember.computed('status', 'canShowErrors', {


### PR DESCRIPTION
class is already included in bindings by default. Add it in the `classNameBindings` cause a duplication.

@spruce can you just confirm?