### PR TITLE
Upgrade <textarea> to ember native component – like {{input}} already does

### DIFF
--- a/addon/components/em-input.js
+++ b/addon/components/em-input.js
@@ -17,6 +17,7 @@ export default FormGroupComponent.extend({
   required: null,
   autofocus: null,
   readonly: null,
+  autoresize: null,
   disabled: null,
   controlWrapper: Ember.computed('form.formLayout', {
     get: function() {

--- a/addon/components/em-input.js
+++ b/addon/components/em-input.js
@@ -16,6 +16,7 @@ export default FormGroupComponent.extend({
   placeholder: null,
   required: null,
   autofocus: null,
+  readonly: null,
   disabled: null,
   controlWrapper: Ember.computed('form.formLayout', {
     get: function() {

--- a/addon/components/em-text.js
+++ b/addon/components/em-text.js
@@ -18,6 +18,7 @@ export default FormGroupComponent.extend({
   cols: null,
   required: null,
   autofocus: null,
+  readonly: null,
   disabled: null,
   controlWrapper: Ember.computed('form.formLayout', function() {
     if (this.get('form.formLayout') === 'horizontal') {

--- a/addon/components/em-text.js
+++ b/addon/components/em-text.js
@@ -12,9 +12,12 @@ export default FormGroupComponent.extend({
   htmlComponent: 'erf-html-text',
   property: null,
   label: null,
+  name: null,
   placeholder: null,
   rows: null,
   cols: null,
+  required: null,
+  autofocus: null,
   disabled: null,
   controlWrapper: Ember.computed('form.formLayout', function() {
     if (this.get('form.formLayout') === 'horizontal') {

--- a/addon/components/em-text.js
+++ b/addon/components/em-text.js
@@ -19,6 +19,7 @@ export default FormGroupComponent.extend({
   required: null,
   autofocus: null,
   readonly: null,
+  autoresize: null,
   disabled: null,
   controlWrapper: Ember.computed('form.formLayout', function() {
     if (this.get('form.formLayout') === 'horizontal') {

--- a/addon/components/html-text.js
+++ b/addon/components/html-text.js
@@ -6,37 +6,6 @@ export default Ember.Component.extend({
   didReceiveAttrs( /*attrs*/ ) {
     this._super(...arguments);
     // set it to the correct value of the selection
-    this.selectedValue = Ember.computed('mainComponent.model.' + this.get('mainComponent.property'), function() {
-      return this.get('mainComponent.model.' + this.get('mainComponent.property'));
-    });
-  },
-  actions: {
-    change: function() {
-      const selectedEl = this.$('textarea')[0];
-      const value = selectedEl.value;
-      this.set('mainComponent.model.' + this.get('mainComponent.property'), value);
-      const changeAction = this.get('action');
-      if(changeAction){
-        changeAction(value);
-      }
-      else{
-        // TODO make deprecate here so everyone switches to new action syntax
-      }
-    },
-    input: function() {
-      // input is always called when input is altert
-      // except in IE9 where when cutting or removing things it doesn't get fired
-      // https://developer.mozilla.org/en-US/docs/Web/Events/input#Browser_compatibility
-      const selectedEl = this.$('textarea')[0];
-      const value = selectedEl.value;
-      this.set('mainComponent.model.' + this.get('mainComponent.property'), value);
-      const changeAction = this.get('action');
-      if(changeAction){
-        changeAction(value);
-      }
-      else{
-        // TODO make deprecate here so everyone switches to new action syntax
-      }
-    }
+    this.selectedValue = Ember.computed.alias('mainComponent.model.' + this.get('mainComponent.property'));
   }
 });

--- a/addon/templates/components/html-input.hbs
+++ b/addon/templates/components/html-input.hbs
@@ -1,11 +1,13 @@
 {{input
+  type=mainComponent.type
+
   placeholder=mainComponent.placeholder
   value=selectedValue
   name=mainComponent.name
-  type=mainComponent.type
   disabled=mainComponent.disabled
   class=(concat "form-control " mainComponent.elementClass)
   id=mainComponent.id
   required=mainComponent.required
   autofocus=mainComponent.autofocus
+  readonly=mainComponent.readonly
 }}

--- a/addon/templates/components/html-input.hbs
+++ b/addon/templates/components/html-input.hbs
@@ -10,4 +10,5 @@
   required=mainComponent.required
   autofocus=mainComponent.autofocus
   readonly=mainComponent.readonly
+  autoresize=mainComponent.autoresize
 }}

--- a/addon/templates/components/html-text.hbs
+++ b/addon/templates/components/html-text.hbs
@@ -9,4 +9,5 @@
   id=mainComponent.id
   required=mainComponent.required
   autofocus=mainComponent.autofocus
+  readonly=mainComponent.readonly
 }}

--- a/addon/templates/components/html-text.hbs
+++ b/addon/templates/components/html-text.hbs
@@ -1,1 +1,12 @@
-<textarea placeholder={{mainComponent.placeholder}} value={{selectedValue}}  rows={{mainComponent.rows}} cols={{mainComponent.cols}} disabled={{mainComponent.disabled}} class="form-control {{mainComponent.elementClass}}" {{action 'change' on='change'}} {{action 'input' on='input'}} id={{mainComponent.id}}></textarea>
+{{textarea
+  rows=mainComponent.rows
+  cols=mainComponent.cols
+  placeholder=mainComponent.placeholder
+  value=selectedValue
+  name=mainComponent.name
+  disabled=mainComponent.disabled
+  class=(concat "form-control " mainComponent.elementClass)
+  id=mainComponent.id
+  required=mainComponent.required
+  autofocus=mainComponent.autofocus
+}}

--- a/addon/templates/components/html-text.hbs
+++ b/addon/templates/components/html-text.hbs
@@ -10,4 +10,5 @@
   required=mainComponent.required
   autofocus=mainComponent.autofocus
   readonly=mainComponent.readonly
+  autoresize=mainComponent.autoresize
 }}

--- a/tests/dummy/app/templates/controls/input.hbs
+++ b/tests/dummy/app/templates/controls/input.hbs
@@ -30,5 +30,6 @@ Standard <i>&lt;input&gt;</i> tag which is a one-line input field that a user ca
     <tr><td>disabled</td><td>Standard HTML5 disabled attribute.</td><td>null</td></tr>
     <tr><td>required</td><td>Standard HTML5 required attribute.</td><td>null</td></tr>
     <tr><td>autofocus</td><td>Standard HTML5 autofocus attribute.</td><td>null</td></tr>
+    <tr><td>readonly</td><td>Standard HTML5 readonly attribute.</td><td>null</td></tr>
     <tr><td>onKeyUp</td><td>If true, errors will show as soon as the user types in the field.</td><td>false</td></tr>
 </table>

--- a/tests/dummy/app/templates/controls/input.hbs
+++ b/tests/dummy/app/templates/controls/input.hbs
@@ -27,6 +27,7 @@ Standard <i>&lt;input&gt;</i> tag which is a one-line input field that a user ca
     <tr><td>name</td><td>The name of the input element.</td><td>null</td></tr>
     <tr><td>placeholder</td><td>The standard input placeholder.</td><td>null</td></tr>
     <tr><td>elementClass</td><td>The class of the input element concatenated with the default 'form-control' class.</td><td>form-control</td></tr>
+    <tr><td>autoresize</td><td>If true, will activate automatic resizing from <a href="https://github.com/tim-evans/ember-autoresize" target="_blank">ember-autoresize addon</a>.</td><td>null</td></tr>
     <tr><td>disabled</td><td>Standard HTML5 disabled attribute.</td><td>null</td></tr>
     <tr><td>required</td><td>Standard HTML5 required attribute.</td><td>null</td></tr>
     <tr><td>autofocus</td><td>Standard HTML5 autofocus attribute.</td><td>null</td></tr>

--- a/tests/dummy/app/templates/controls/text.hbs
+++ b/tests/dummy/app/templates/controls/text.hbs
@@ -30,5 +30,6 @@ Standard <i>&lt;textarea&gt;</i> tag which is a multi-line text input control.
     <tr><td>disabled</td><td>Standard HTML5 disabled attribute.</td><td>null</td></tr>
     <tr><td>required</td><td>Standard HTML5 required attribute.</td><td>null</td></tr>
     <tr><td>autofocus</td><td>Standard HTML5 autofocus attribute.</td><td>null</td></tr>
+    <tr><td>readonly</td><td>Standard HTML5 readonly attribute.</td><td>null</td></tr>
     <tr><td>onKeyUp</td><td>If true, errors will show as soon as the user types in the field.</td><td>false</td></tr>
 </table>

--- a/tests/dummy/app/templates/controls/text.hbs
+++ b/tests/dummy/app/templates/controls/text.hbs
@@ -23,6 +23,12 @@ Standard <i>&lt;textarea&gt;</i> tag which is a multi-line text input control.
     <tr><td>property</td><td>The property name in the model instance bound to the form</td><td>none, value is required.</td></tr>
     <tr><td>rows</td><td>Specifies the height of the text area (in lines)</td><td>Browser specific, usually 2</td></tr>
     <tr><td>cols</td><td>Specifies the width of the text area (in columns)</td><td>Browser specific, usually 20</td></tr>
-    <tr><td>disabled</td><td>boolean, disables the input</td><td>false</td></tr>
+    <tr><td>cid</td><td>If set, the specified identifier will be set as the <i>id</i> attribute of the <i>input</i> tag.</td><td>Ember's default ID</td></tr>
+    <tr><td>name</td><td>The name of the input element.</td><td>null</td></tr>
+    <tr><td>placeholder</td><td>The standard input placeholder.</td><td>null</td></tr>
+    <tr><td>elementClass</td><td>The class of the input element concatenated with the default 'form-control' class.</td><td>form-control</td></tr>
+    <tr><td>disabled</td><td>Standard HTML5 disabled attribute.</td><td>null</td></tr>
+    <tr><td>required</td><td>Standard HTML5 required attribute.</td><td>null</td></tr>
+    <tr><td>autofocus</td><td>Standard HTML5 autofocus attribute.</td><td>null</td></tr>
     <tr><td>onKeyUp</td><td>If true, errors will show as soon as the user types in the field.</td><td>false</td></tr>
 </table>

--- a/tests/dummy/app/templates/controls/text.hbs
+++ b/tests/dummy/app/templates/controls/text.hbs
@@ -27,6 +27,7 @@ Standard <i>&lt;textarea&gt;</i> tag which is a multi-line text input control.
     <tr><td>name</td><td>The name of the input element.</td><td>null</td></tr>
     <tr><td>placeholder</td><td>The standard input placeholder.</td><td>null</td></tr>
     <tr><td>elementClass</td><td>The class of the input element concatenated with the default 'form-control' class.</td><td>form-control</td></tr>
+    <tr><td>autoresize</td><td>If true, will activate automatic resizing from <a href="https://github.com/tim-evans/ember-autoresize" target="_blank">ember-autoresize addon</a>.</td><td>null</td></tr>
     <tr><td>disabled</td><td>Standard HTML5 disabled attribute.</td><td>null</td></tr>
     <tr><td>required</td><td>Standard HTML5 required attribute.</td><td>null</td></tr>
     <tr><td>autofocus</td><td>Standard HTML5 autofocus attribute.</td><td>null</td></tr>


### PR DESCRIPTION
#### Commits in order:

----

1. 	Update textarea to use native ember helper

  + this literally uses the logic from https://github.com/piceaTech/ember-rapid-forms/commit/24cb1a7c46d21236d81bfe1ff9de6b3e48b1e5b6 to upgrade to ember native component


2.    Add `readonly` attribute to the two now that I know it is missing

3.    Add `autoresize` attribute to solve the original issue: #109 

---