### PR TITLE
Enable HTML5 required validation on 'em-select' elements

### DIFF
--- a/addon/templates/components/html-select.hbs
+++ b/addon/templates/components/html-select.hbs
@@ -1,6 +1,6 @@
-<select {{action 'change' on='change'}} class="form-control {{mainComponent.elementClass}}" id={{mainComponent.id}}>
+<select {{action 'change' on='change'}} class="form-control {{mainComponent.elementClass}}" id={{mainComponent.id}} required=mainComponent.required>
 {{#if mainComponent.prompt}}
-  <option value="null" selected={{eq null selectedValue}}>
+  <option value="" selected={{eq "" selectedValue}}>
     {{mainComponent.prompt}}
   </option>
 {{/if}}


### PR DESCRIPTION
The value has to be "" for the select to be [considered empty](http://www.w3schools.com/tags/att_select_required.asp).

Also, one has to be able to mark the field as required.