### PR TITLE
Update ember-cli-htmlbars dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   ],
   "dependencies": {
     "ember-validations": "2.0.0-alpha.4",
-    "ember-cli-htmlbars": "0.7.4",
+    "ember-cli-htmlbars": "^1.0.8",
     "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {


### PR DESCRIPTION
On Ember-CLI 2.6.2, you will get this deprecation warning:

```
https://github.com/danconnell/ember-rapid-forms/commit/02cd5470def2dc20a2b4fe9b0e1567354bef46d3
```

To resolve this, the ember-cli-htmlbars dependency needs to be updated to at least 1.0.8. See https://github.com/ember-cli/ember-cli-htmlbars/issues/77