### PR TITLE
Fix required on em-select

### DIFF
--- a/addon/templates/components/html-select.hbs
+++ b/addon/templates/components/html-select.hbs
@@ -1,4 +1,4 @@
-<select {{action 'change' on='change'}} class="form-control {{mainComponent.elementClass}}" id={{mainComponent.id}} required=mainComponent.required>
+<select {{action 'change' on='change'}} class="form-control {{mainComponent.elementClass}}" id={{mainComponent.id}} required={{mainComponent.required}}>
 {{#if mainComponent.prompt}}
   <option value="" selected={{eq "" selectedValue}}>
     {{mainComponent.prompt}}

--- a/tests/unit/components/em-select-test.js
+++ b/tests/unit/components/em-select-test.js
@@ -144,6 +144,12 @@ test('the "for" of the label is the "id" of the select', function(assert) {
   assert.equal(this.$('select').attr('id'), this.$('label').attr('for'), 'the "for" of the label is not the "id" of the select');
 });
 
+test('Input can be a required field', function(assert) {
+  this.render(hbs`{{em-select required=true}}`);
+
+  assert.ok(this.$().find('select').attr('required'), 'select becomes a required field');
+});
+
 // test('em-select can select multiple items', function(assert) {
 
 //   this.set('fruitOptions', fruitOptions);


### PR DESCRIPTION
It wasn't working as intended after https://github.com/piceaTech/ember-rapid-forms/pull/119/files.

Resulting HTML on the page was `required="mainComponent.required"`, which is obviously not correct.

This fixes it to work as intended.