### PR TITLE
Updates to em-checkbox (also fixes issue #101)

### DIFF
--- a/addon/components/em-checkbox.js
+++ b/addon/components/em-checkbox.js
@@ -12,6 +12,10 @@ export default FormGroupComponent.extend({
   validations: false,
   yieldInLabel: true,
   htmlComponent: 'erf-html-checkbox',
+  elementClass: null,
+  required: null,
+  autofocus: null,
+  disabled: null,
   wrapperClass: Ember.computed('form.formLayout', {
     get: function() {
       if (this.get('form.formLayout') === 'horizontal') {

--- a/addon/components/html-checkbox.js
+++ b/addon/components/html-checkbox.js
@@ -3,13 +3,9 @@ import layout from '../templates/components/html-checkbox';
 
 export default Ember.Component.extend({
   layout: layout,
-  tagName: 'input',
-  attributeBindings: ['type', 'checked'],
 
-  type: "checkbox",
   checked: false,
   init: function() {
-    this.elementId = this.get('mainComponent.id');
     this._super(...arguments);
   },
   didReceiveAttrs( /*attrs*/ ) {
@@ -19,25 +15,27 @@ export default Ember.Component.extend({
       return this.get('mainComponent.model.' + this.get('mainComponent.property'));
     });
   },
-  change: function() {
-    const selectedEl = this.$()[0];
-    const checked = selectedEl.checked;
-    this.set('mainComponent.model.' + this.get('mainComponent.property'), checked);
-    const changeAction = this.get('action');
-    if (changeAction) {
-      changeAction(checked);
-    }
-  },
-  input: function() {
-    // input is always called when input is altert
-    // except in IE9 where when cutting or removing things it doesn't get fired
-    // https://developer.mozilla.org/en-US/docs/Web/Events/input#Browser_compatibility
-    const selectedEl = this.$()[0];
-    const checked = selectedEl.checked;
-    this.set('mainComponent.model.' + this.get('mainComponent.property'), checked);
-    const changeAction = this.get('action');
-    if (changeAction) {
-      changeAction(checked);
+  actions: {
+    change: function() {
+      const selectedEl = this.$('input')[0];
+      const checked = selectedEl.checked;
+      this.set('mainComponent.model.' + this.get('mainComponent.property'), checked);
+      const changeAction = this.get('action');
+      if (changeAction) {
+        changeAction(checked);
+      }
+    },
+    input: function() {
+      // input is always called when input is altered
+      // except in IE9 where when cutting or removing things it doesn't get fired
+      // https://developer.mozilla.org/en-US/docs/Web/Events/input#Browser_compatibility
+      const selectedEl = this.$('input')[0];
+      const checked = selectedEl.checked;
+      this.set('mainComponent.model.' + this.get('mainComponent.property'), checked);
+      const changeAction = this.get('action');
+      if (changeAction) {
+        changeAction(checked);
+      }
     }
   }
 });

--- a/addon/templates/components/control-within-label.hbs
+++ b/addon/templates/components/control-within-label.hbs
@@ -1,4 +1,4 @@
-{{#em-form-label text=label horiClass='' inlineClass='' form=form for=mainComponent.id}}
+{{#em-form-label text=label horiClass='' inlineClass='' form=form for=mainComponent.id extraClass=extraClass}}
     {{form-group-control controlWrapper=controlWrapper
       mainComponent=mainComponent form=form}}
 {{/em-form-label}}

--- a/addon/templates/components/html-checkbox.hbs
+++ b/addon/templates/components/html-checkbox.hbs
@@ -1,0 +1,13 @@
+<input
+  type="checkbox"
+  {{action "change" on="change"}}
+  {{action "input" on="input"}}
+  
+  checked={{checked}}
+  name={{mainComponent.name}}
+  id={{mainComponent.id}}
+  disabled={{mainComponent.disabled}}
+  class={{mainComponent.elementClass}}
+  required={{mainComponent.required}}
+  autofocus={{mainComponent.autofocus}}
+/>

--- a/tests/dummy/app/templates/controls/checkbox.hbs
+++ b/tests/dummy/app/templates/controls/checkbox.hbs
@@ -21,5 +21,10 @@ Checkboxes let a user select or deselect an option.
     <tr><th>Param name</th><th>Description</th><th>Default</th></tr>
     <tr><td>label</td><td>The label of the input</td><td>A humanized form of the property name</td></tr>
     <tr><td>property</td><td>The property name in the model instance bound to the form</td><td>none, value is required.</td></tr>
+    <tr><td>cid</td><td>If set, the specified identifier will be set as the <i>id</i> attribute of the <i>input</i> tag.</td><td>Ember's default ID</td></tr>
+    <tr><td>elementClass</td><td>The class of the input (checkbox) element.</td><td>ember-checkbox</td></tr>
+    <tr><td>disabled</td><td>Standard HTML5 disabled attribute.</td><td>null</td></tr>
+    <tr><td>required</td><td>Standard HTML5 required attribute.</td><td>null</td></tr>
+    <tr><td>autofocus</td><td>Standard HTML5 autofocus attribute.</td><td>null</td></tr>
 </table>
 

--- a/tests/unit/components/em-form-checkbox-test.js
+++ b/tests/unit/components/em-form-checkbox-test.js
@@ -54,3 +54,46 @@ test('a checkbox without a label updates data', function(assert) {
     someModel.set('userAgree', false);
   });
 });
+
+test('Checkbox renders with custom css', function(assert) {
+  this.render(hbs`{{em-checkbox label='My label' elementClass="col-md-6" controlWrapper="col-md-6" labelClass="col-md-4"}}`);
+
+  assert.ok(this.$().find('label').hasClass('col-md-4'), 'Label has correct class');
+  assert.ok(this.$().find('input').parent().parent().hasClass('col-md-6'), 'Checkbox parent has correct class');
+  assert.ok(this.$().find('input').hasClass('col-md-6'), 'Checkbox input has correct class');
+});
+
+test('Checkbox can be disabled', function(assert) {
+
+  this.render(hbs`{{em-checkbox disabled=true}}`);
+
+  assert.ok(this.$().find('input').attr('disabled'), 'checkbox input renders disabled');
+});
+
+test('cid correctly sets the id for the checkbox and it\'s label', function(assert) {
+  assert.expect(2);
+  this.render(hbs`{{em-checkbox label="some label" cid='test-cid'}}`);
+
+  assert.equal(this.$('input').attr('id'), 'test-cid', 'checkbox input has correct id');
+  assert.equal(this.$('label').attr('for'), 'test-cid', 'label has correct \'for\'');
+});
+
+test('the "for" of the label is the "id" of the checkbox', function(assert) {
+  this.render(hbs`{{em-checkbox label="some label" property='test-cid'}}`);
+
+  assert.equal(this.$('input').attr('id'), this.$('label').attr('for'), 'the "for" of the label is not the "id" of the checkbox input');
+});
+
+test('Checkbox can be a required field', function(assert) {
+
+  this.render(hbs`{{em-checkbox required=true}}`);
+
+  assert.ok(this.$().find('input').attr('required'), 'checkbox input becomes a required field');
+});
+
+test('Checkbox can be autofocused', function(assert) {
+
+  this.render(hbs`{{em-checkbox autofocus=true}}`);
+
+  assert.ok(this.$().find('input').attr('autofocus'), 'checkbox input has autofocus');
+});


### PR DESCRIPTION
The following fields are now supported in em-checkbox:
- cid
- elementClass
- disabled (issue #101)
- required
- autofocus

I added tests to match the features. I also updated the documentation in the dummy app to reflect the new properties.

This PR also bundles a fix to label-in-control to support the labelClass attribute.