### PR TITLE
[FIX] focusOut always enabled canShowErrors, but without validation ...

### DIFF
--- a/addon/components/em-form-group.js
+++ b/addon/components/em-form-group.js
@@ -116,7 +116,9 @@ export default Ember.Component.extend(InFormMixin, HasPropertyMixin, HasProperty
   Listen to the focus out of the form group and display the errors
    */
   focusOut() {
-    return this.set('canShowErrors', true);
+    if (!Ember.isEmpty(this.get('model.' + this.get('property')))) {
+      return this.set('canShowErrors', true);
+    }
   },
 
   /*


### PR DESCRIPTION
if the property value is empty, so a "presence" error would have not shown up. Now canShowErrors is only set to true if the model property is not empty.

If a focusOut is now triggered with an empty value, neither success nor error shows up, as neither the validation has been done nor canShowErrors is set to true.

If a focusOut is now triggered with a non-empty value, the validation is triggered and canShowErrors is set to true.