### PR TITLE
Switch to using ember-cp-validations

### DIFF
--- a/addon/mixins/ember-cp-validations-helper.js
+++ b/addon/mixins/ember-cp-validations-helper.js
@@ -9,32 +9,24 @@ export default Ember.Mixin.create({
   init() {
     this._super(...arguments);
 
-    this.eachAttribute(attribute=> {
-      this.addObserver(attribute, function () {
-        this._copyErrors(this, attribute);
-      });
-    });
-
-    this.eachRelationship(attribute=> {
-      this.addObserver(attribute, function () {
-        this._copyErrors(this, attribute);
+    this.get('validations.validatableAttributes').forEach((va) =>{
+      this.addObserver(va, `validations.attrs.${va}.messages`, () => {
+        this._copyErrors(this, va);
       });
     });
   },
 
   validate() {
     return this.get('validations').validate(...arguments)
-      .then(()=> {
+      .then((validations)=> {
         const modelErrors = this.get('errors');
 
         if (this instanceof DS.Model && !Ember.isNone(modelErrors) && Ember.canInvoke(modelErrors, 'add')) {
-          this.eachAttribute(attribute=> {
-            this._copyErrors(this, attribute);
-          });
-          this.eachRelationship(attribute=> {
-            this._copyErrors(this, attribute);
+          this.get('validations.validatableAttributes').forEach((va) =>{
+            this._copyErrors(this, va);
           });
         }
+        return validations;
       });
   },
 

--- a/addon/mixins/ember-cp-validations-helper.js
+++ b/addon/mixins/ember-cp-validations-helper.js
@@ -3,7 +3,6 @@ Copied from GCorbel from https://github.com/piceaTech/ember-rapid-forms/issues/1
 */
 
 import Ember from 'ember';
-import DS from 'ember-data';
 
 export default Ember.Mixin.create({
   init() {
@@ -21,8 +20,7 @@ export default Ember.Mixin.create({
     return this.get('validations').validate(...arguments)
       .then((validations)=> {
         const modelErrors = this.get('errors');
-
-        if (this instanceof DS.Model && !Ember.isNone(modelErrors) && Ember.canInvoke(modelErrors, 'add')) {
+        if (!Ember.isNone(modelErrors) && Ember.canInvoke(modelErrors, 'add')) {
           this.get('validations.validatableAttributes').forEach((va) =>{
             this._copyErrors(this, va);
           });

--- a/addon/mixins/ember-cp-validations-helper.js
+++ b/addon/mixins/ember-cp-validations-helper.js
@@ -1,0 +1,69 @@
+/*
+Copied from GCorbel from https://github.com/piceaTech/ember-rapid-forms/issues/139#issuecomment-257280656
+*/
+
+import Ember from 'ember';
+import DS from 'ember-data';
+
+export default Ember.Mixin.create({
+  init() {
+    this._super(...arguments);
+
+    this.eachAttribute(attribute=> {
+      this.addObserver(attribute, function () {
+        this._copyErrors(this, attribute);
+      });
+    });
+
+    this.eachRelationship(attribute=> {
+      this.addObserver(attribute, function () {
+        this._copyErrors(this, attribute);
+      });
+    });
+  },
+
+  validate() {
+    return this.get('validations').validate(...arguments)
+      .then(()=> {
+        const modelErrors = this.get('errors');
+
+        if (this instanceof DS.Model && !Ember.isNone(modelErrors) && Ember.canInvoke(modelErrors, 'add')) {
+          this.eachAttribute(attribute=> {
+            this._copyErrors(this, attribute);
+          });
+          this.eachRelationship(attribute=> {
+            this._copyErrors(this, attribute);
+          });
+        }
+      });
+  },
+
+  _copyErrors(model, attribute) {
+    if (model.currentState.stateName === 'root.loaded.saved' || model.currentState.stateName === 'root.deleted.saved') {
+      return;
+    }
+
+    const modelErrors = model.get('errors');
+    const wasEmpty = modelErrors.get('isEmpty');
+
+    if (modelErrors.get(attribute)) {
+      modelErrors._remove(attribute);
+    }
+
+    const messages = this.get(`validations.attrs.${attribute}.messages`);
+
+    if (messages && messages.length > 0) {
+      messages.forEach(m=> {
+        modelErrors._add(attribute, m);
+      });
+    }
+
+    const isEmpty = modelErrors.get('isEmpty');
+
+    if (wasEmpty && !isEmpty) {
+      modelErrors.trigger('becameInvalid');
+    } else if (!wasEmpty && isEmpty) {
+      modelErrors.trigger('becameValid');
+    }
+  }
+});

--- a/addon/mixins/ember-cp-validations-helper.js
+++ b/addon/mixins/ember-cp-validations-helper.js
@@ -9,6 +9,7 @@ export default Ember.Mixin.create({
   init() {
     this._super(...arguments);
 
+    // when there is a validation error copy its message into the format we currently understand
     this.get('validations.validatableAttributes').forEach((va) =>{
       this.addObserver(va, `validations.attrs.${va}.messages`, () => {
         this._copyErrors(this, va);
@@ -29,7 +30,7 @@ export default Ember.Mixin.create({
         return validations;
       });
   },
-
+  // gets called when a message is added (that means there is a validation-error)
   _copyErrors(model, attribute) {
     if (model.currentState.stateName === 'root.loaded.saved' || model.currentState.stateName === 'root.deleted.saved') {
       return;
@@ -44,6 +45,7 @@ export default Ember.Mixin.create({
 
     const messages = this.get(`validations.attrs.${attribute}.messages`);
 
+    // manually add them to the errorObject
     if (messages && messages.length > 0) {
       messages.forEach(m=> {
         modelErrors._add(attribute, m);
@@ -52,6 +54,7 @@ export default Ember.Mixin.create({
 
     const isEmpty = modelErrors.get('isEmpty');
 
+    // trigger the method whether a model is now valid or not
     if (wasEmpty && !isEmpty) {
       modelErrors.trigger('becameInvalid');
     } else if (!wasEmpty && isEmpty) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cp-validations": "3.1.2",
     "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-rapid-forms",
-  "version": "1.0.0-beta9",
+  "version": "1.0.0-beta10",
   "description": "Intuitive, Smart and Beautiful Forms for Ember.js",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-validations": "2.0.0-alpha.4",
     "ember-cli-htmlbars": "1.0.8",
     "ember-cli-babel": "^5.1.6"
   },

--- a/tests/dummy/app/components/x-sidebar.js
+++ b/tests/dummy/app/components/x-sidebar.js
@@ -42,5 +42,8 @@ export default Ember.Component.extend({
             route: 'controls.custom-styles',
             text: 'Custom Styles'
         }])
+    }, {
+        route: 'ember-cp-validations',
+        text: 'ember-cp-validations'
     }])
 });

--- a/tests/dummy/app/mixins/ember-cp-validations-helper.js
+++ b/tests/dummy/app/mixins/ember-cp-validations-helper.js
@@ -1,0 +1,4 @@
+//import Ember from 'ember';
+import emberCpValidationsHelper from 'ember-rapid-forms/mixins/ember-cp-validations-helper';
+
+export default emberCpValidationsHelper;

--- a/tests/dummy/app/mixins/ember-cp-validations-helper.js
+++ b/tests/dummy/app/mixins/ember-cp-validations-helper.js
@@ -1,4 +1,3 @@
-//import Ember from 'ember';
 import emberCpValidationsHelper from 'ember-rapid-forms/mixins/ember-cp-validations-helper';
 
 export default emberCpValidationsHelper;

--- a/tests/dummy/app/models/person-with-cp-validations.js
+++ b/tests/dummy/app/models/person-with-cp-validations.js
@@ -22,8 +22,6 @@ const Validations = buildValidations({
   gender: validator('presence', true),
 });
 
-
-
 const person = DS.Model.extend(Validations, InputErrors, helper, {
   firstName: DS.attr('string', { defaultValue: null }),
   lastName: DS.attr('string', { defaultValue: null }),

--- a/tests/dummy/app/models/person-with-cp-validations.js
+++ b/tests/dummy/app/models/person-with-cp-validations.js
@@ -1,0 +1,65 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+import { validator, buildValidations } from 'ember-cp-validations';
+import InputErrors from 'ember-rapid-forms/mixins/input-errors';
+import helper from 'ember-rapid-forms/mixins/ember-cp-validations-helper';
+
+const Validations = buildValidations({
+  fullName: [
+    validator('format', {
+      regex: /^[^\s]+(\s[^\s]+)+$/,
+      message: 'enter a first and last name'
+    }),
+    validator('presence', true),
+  ],
+  password: [
+    validator('presence', true),
+    validator('length', {
+      min: 6
+    })
+  ],
+  comment: validator('presence', true),
+  gender: validator('presence', true),
+});
+
+
+
+const person = DS.Model.extend(Validations, InputErrors, helper, {
+  firstName: DS.attr('string', { defaultValue: null }),
+  lastName: DS.attr('string', { defaultValue: null }),
+  password: DS.attr('string'),
+  comment: DS.attr('string'),
+  active: DS.attr('boolean'),
+  gender: DS.attr('string'),
+  nameHasValue: Ember.computed('fullName', {
+    get: function() {
+      return !!this.get('fullName');
+    }
+  }),
+
+  fullName: Ember.computed('firstName', 'lastName', {
+    //jshint unused:false
+    get: function() {
+      if (this.get('firstName')) {
+        return `${this.get('firstName')} ${this.get('lastName')}`;
+      }
+      else {
+        return null;
+      }
+    },
+    set: function(key, value) {
+      let [firstName, lastName] = value.split(/\s+/);
+      firstName = firstName ? firstName : null;
+      lastName = lastName ? lastName : null;
+      this.setProperties({ firstName, lastName });
+      return value;
+    }
+  }),
+
+  asjson: Ember.computed('fullName', 'firstName', 'lastName', 'password', 'comment', 'active', 'gender', function() {
+    return "fullName: " + (this.get('fullName')) + ", firstName: " + (this.get('firstName')) + ", lastName: " + (this.get('lastName')) + ", password: " + (this.get('password')) + ", comment: " + (this.get('comment')) + ", active: " + (this.get('active')) + ", gender: " + (this.get('gender'));
+  })
+});
+
+
+export default person;

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -25,6 +25,7 @@ Router.map(function() {
     this.route('wrapped-input');
     this.route('custom-styles');
   });
+  this.route('ember-cp-validations');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/ember-cp-validations.js
+++ b/tests/dummy/app/routes/ember-cp-validations.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model: function() {
+    return this.get('store').createRecord('person-with-cp-validations', {
+            name: "",
+            password: "",
+            comment: "",
+            active: false,
+            gender: "M"
+        });
+  }
+});

--- a/tests/dummy/app/templates/ember-cp-validations.hbs
+++ b/tests/dummy/app/templates/ember-cp-validations.hbs
@@ -1,0 +1,25 @@
+<h1>Overview</h1>
+<p>
+<b>Ember Forms</b> is a small library for <i>Ember.js</i> that allows you to create astonishing forms
+    with support for <i> layouts, styles & validations</i> thanks to the combination of the beauty of <i>Bootstrap</i> and the power of <i>Ember</i>.
+</p>
+
+<hr/>
+
+<h4>And here is the result in a nutshell...</h4>
+
+<a href="http://jsbin.com/pexolude/201" target="_blank" class="btn btn-warning jsbin pull-right">jsBin</a>
+<div class="well line-example">
+    {{form-sample model=model}}
+</div>
+<div class="well line-example">
+    {{model.asjson}}
+</div>
+
+<h1>Want to see more?</h1>
+<p>
+    For getting started & installation steps, please visit {{#link-to 'getstarted'}}Getting Started{{/link-to}}
+</p>
+<p>
+    To see controls in action, visit {{#link-to 'controls'}}Controls{{/link-to}}
+</p>

--- a/tests/unit/mixins/ember-cp-validations-helper-test.js
+++ b/tests/unit/mixins/ember-cp-validations-helper-test.js
@@ -1,3 +1,4 @@
+/*global expect*/
 import Ember from 'ember';
 import EmberCpValidationsHelperMixin from 'ember-rapid-forms/mixins/ember-cp-validations-helper';
 import { moduleFor, test } from 'ember-qunit';
@@ -21,4 +22,47 @@ test('it works', function(assert) {
   assert.ok(EmberCpValidationsHelperObject);
   let subject = EmberCpValidationsHelperObject.create();
   assert.ok(subject);
+});
+
+test('it works on Object', function(assert) {
+  expect(4);
+  let ValidationsMixin = Ember.Mixin.create({
+    validations: {
+      validatableAttributes: ['username'],
+      attrs:{
+        username: {
+          messages: ['Can\'t be blank']
+        }
+      },
+      validate() {
+        var promise = new Ember.RSVP.Promise((resolve) => {
+          resolve('ok!');
+        });
+        return promise;
+      },
+    },
+    currentState:{
+      stateName: 'notDeleted:P'
+    }
+  });
+
+  let EmberCpValidationsHelperObject = Ember.Object.extend(ValidationsMixin, EmberCpValidationsHelperMixin, {
+    username: "",
+    errors: Ember.Object.create({
+      add(/*attribute, messages*/) {
+        // we need it currently for testing
+      },
+      _add(attribute, message) {
+        this.set(attribute, message);
+      },
+    })
+  });
+
+  assert.ok(EmberCpValidationsHelperObject);
+  let subject = EmberCpValidationsHelperObject.create();
+  assert.ok(subject);
+  assert.notOk(subject.get('errors.username'));
+  subject.validate().then(function(){
+    assert.ok(subject);
+  });
 });

--- a/tests/unit/mixins/ember-cp-validations-helper-test.js
+++ b/tests/unit/mixins/ember-cp-validations-helper-test.js
@@ -4,7 +4,6 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('mixin:ember-cp-validations-helper', 'Unit | Mixin | ember cp validations helper');
 
-// Replace this with your real tests.
 test('it works', function(assert) {
   let ValidationsMixin = Ember.Mixin.create({
     validate() {

--- a/tests/unit/mixins/ember-cp-validations-helper-test.js
+++ b/tests/unit/mixins/ember-cp-validations-helper-test.js
@@ -1,12 +1,25 @@
 import Ember from 'ember';
-import ECpValidationsHelperMixin from 'ember-rapid-forms/mixins/ember-cp-validations-helper';
-import { module, test } from 'qunit';
+import EmberCpValidationsHelperMixin from 'ember-rapid-forms/mixins/ember-cp-validations-helper';
+import { moduleFor, test } from 'ember-qunit';
 
-module('Unit | Mixin | ember cp validations helper');
+moduleFor('mixin:ember-cp-validations-helper', 'Unit | Mixin | ember cp validations helper');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  let EmberCpValidationsHelperObject = Ember.Object.extend(EmberCpValidationsHelperMixin);
+  let ValidationsMixin = Ember.Mixin.create({
+    validate() {
+      var promise = new Ember.RSVP.Promise((resolve) => {
+        resolve('ok!');
+      });
+      return promise;
+    },
+    validations: {
+      validatableAttributes: []
+    }
+  });
+
+  let EmberCpValidationsHelperObject = Ember.Object.extend(ValidationsMixin, EmberCpValidationsHelperMixin);
+  assert.ok(EmberCpValidationsHelperObject);
   let subject = EmberCpValidationsHelperObject.create();
   assert.ok(subject);
 });

--- a/tests/unit/mixins/ember-cp-validations-helper-test.js
+++ b/tests/unit/mixins/ember-cp-validations-helper-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import ECpValidationsHelperMixin from 'ember-rapid-forms/mixins/ember-cp-validations-helper';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | ember cp validations helper');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let EmberCpValidationsHelperObject = Ember.Object.extend(EmberCpValidationsHelperMixin);
+  let subject = EmberCpValidationsHelperObject.create();
+  assert.ok(subject);
+});

--- a/tests/unit/mixins/ember-cp-validations-helper-test.js
+++ b/tests/unit/mixins/ember-cp-validations-helper-test.js
@@ -19,13 +19,14 @@ test('it works', function(assert) {
   });
 
   let EmberCpValidationsHelperObject = Ember.Object.extend(ValidationsMixin, EmberCpValidationsHelperMixin);
-  assert.ok(EmberCpValidationsHelperObject);
   let subject = EmberCpValidationsHelperObject.create();
+
+  assert.ok(EmberCpValidationsHelperObject);
   assert.ok(subject);
 });
 
 test('it works on Object', function(assert) {
-  expect(4);
+  expect(5);
   let ValidationsMixin = Ember.Mixin.create({
     validations: {
       validatableAttributes: ['username'],
@@ -58,11 +59,14 @@ test('it works on Object', function(assert) {
     })
   });
 
-  assert.ok(EmberCpValidationsHelperObject);
   let subject = EmberCpValidationsHelperObject.create();
+
+  assert.ok(EmberCpValidationsHelperObject);
   assert.ok(subject);
   assert.notOk(subject.get('errors.username'));
-  subject.validate().then(function(){
+
+  subject.validate().then(function() {
     assert.ok(subject);
+    assert.equal(subject.get('errors.username'), 'Can\'t be blank');
   });
 });


### PR DESCRIPTION
## Why are we switching?

As discussed in #139 the currently used solution is no longer supported by their maintainers, that's why I think it is time to finally switch to a supported solution. (Nice Side-effect: we finally can support server-side errors)

## Which version will the change be happening?

In Version 1.0 (hopefully released before the end of this year) we will still be supporting ember-validations and ember-cp-validations (via a mixin)

In Version 2.0 we are gonna drop support for ember-validations. This version is gonna be released by june 2017 (hopefully) 

## What still needs to be done:
- [x] make sure tests work correctly with ECV
- [x] make sure ECV works together with computed props on model
- [ ] update version number
- [x] make it work without ember-data


## Further questions

If anything is unclear or you have a general question feel free to ask.
