### PR TITLE
Fix deprecation warning caused by using @each >1 level deep

### DIFF
--- a/addon/components/em-form-group.js
+++ b/addon/components/em-form-group.js
@@ -157,9 +157,13 @@ export default Ember.Component.extend(HasPropertyMixin, HasPropertyValidationMix
     }
   }),
 
-  required: Ember.computed('property', 'validations.attrs.@each.options.presence.presence', function () {
+  propertyOptions: Ember.computed('property', 'validations.attrs.@each.options', function() {
     const property = this.get('property');
 
-    return this.get(`model.validations.attrs.${property}.options.presence.presence`) || false;
+    return this.get(`model.validations.attrs.${property}.options`) || false;
+  }),
+
+  required: Ember.computed('propertyOptions.presence.presence', function () {
+    return this.get('propertyOptions.presence.presence') || false;
   })
 });


### PR DESCRIPTION
On Ember 2.11, I get this warning on any page which has an `em-form` component: 

"WARNING: Dependent keys containing @each only work one level deep. You used the key "validations.attrs.@each.options.presence.presence" which is invalid. Please create an intermediary computed property."

 https://puu.sh/u7wTA/f134d539cd.png

This PR fixes this warning by creating an intermediary computed property, as advised by the warning. No functional changes.