### PR TITLE
Avoid `Ember.inject.service()` for optional `i18n`

### DIFF
--- a/addon/components/em-form-group.js
+++ b/addon/components/em-form-group.js
@@ -33,7 +33,9 @@ export default Ember.Component.extend(HasPropertyMixin, HasPropertyValidationMix
   classNameBindings: ['class', 'hasSuccess', 'hasWarning', 'hasError', 'validationIcons:has-feedback', 'required'],
   attributeBindings: ['disabled'],
   canShowErrors: false,
-  i18n: Ember.inject.service(),
+  i18n: Ember.computed(function() {
+    return Ember.getOwner(this).lookup('service:i18n');
+  }),
 
   hasSuccess: Ember.computed('status', 'canShowErrors', {
     get: function() {


### PR DESCRIPTION
When an object that utilizes an `Ember.inject.service()` is looked up the  first time, Ember's DI system confirms that the service being injected is actually present and known to the system. If the service is not present it throws an error.

In the use case of this addon, `i18n` is intended to be an optional service and may not be present. If we use `Ember.inject.service()` in this context we loose the ability for it to be optional.

This commit changes things around to avoid using `Ember.inject.service` and instead uses `getOwner(this).lookup('service:i18n')` (which returns `undefined` if the service is not found).