### PR TITLE
Fixed Ember warning caused by using @each > one level deep

### DIFF
--- a/addon/mixins/input-component.js
+++ b/addon/mixins/input-component.js
@@ -57,10 +57,14 @@ export default Mixin.create(HasPropertyMixin, HasPropertyValidationMixin, HasIdM
     }
   }),
 
-  required: computed('property', 'validations.attrs.@each.options.presence.presence', function () {
+  propertyOptions: Ember.computed('property', 'validations.attrs.@each.options', function() {
     const property = this.get('property');
 
-    return this.get(`model.validations.attrs.${property}.options.presence.presence`) || false;
+    return this.get(`model.validations.attrs.${property}.options`) || false;
+  }),
+
+  required: Ember.computed('propertyOptions.presence.presence', function() {
+    return this.get('propertyOptions.presence.presence') || false;
   }),
 
   formSubmitted: observer('form.isSubmitted', 'form.showErrorsOnSubmit', 'errors.length', function () {

--- a/addon/mixins/input-component.js
+++ b/addon/mixins/input-component.js
@@ -57,13 +57,13 @@ export default Mixin.create(HasPropertyMixin, HasPropertyValidationMixin, HasIdM
     }
   }),
 
-  propertyOptions: Ember.computed('property', 'validations.attrs.@each.options', function() {
+  propertyOptions: computed('property', 'validations.attrs.@each.options', function() {
     const property = this.get('property');
 
     return this.get(`model.validations.attrs.${property}.options`) || false;
   }),
 
-  required: Ember.computed('propertyOptions.presence.presence', function() {
+  required: computed('propertyOptions.presence.presence', function() {
     return this.get('propertyOptions.presence.presence') || false;
   }),
 


### PR DESCRIPTION
If using Ember >= 2.11, this warning can appear in the console:

"WARNING: Dependent keys containing @each only work one level deep. You used the key "validations.attrs.@each.options.presence.presence" which is invalid. Please create an intermediary computed property." https://puu.sh/vamdd/e97abeb498.png

This has happened here before (https://github.com/piceaTech/ember-rapid-forms/pull/152), so I implemented the same solution.

No functional changes.