### PR TITLE
Fix checkbox HTML to match how it used to be rendered

### DIFF
--- a/addon/components/em-checkbox-input.js
+++ b/addon/components/em-checkbox-input.js
@@ -5,14 +5,14 @@ const { Component, computed } = Ember;
 
 export default Component.extend({
   layout: layout,
-  tagName: computed('checkboxWrapper', {
-    get() {
-      if (this.get('checkboxWrapper')) {
-        return 'div';
-      }
-
-      return '';
+  tagName: '',
+  classNameBindings: ['checkboxWrapper'],
+  didReceiveAttrs() {
+    this._super(...arguments);
+    if (this.get('checkboxWrapper')) {
+      this.set('tagName', 'div');
+    } else {
+      this.set('tagName', '');
     }
-  }),
-  classNameBindings: ['checkboxWrapper']
+  },
 });

--- a/addon/components/em-checkbox-input.js
+++ b/addon/components/em-checkbox-input.js
@@ -6,13 +6,17 @@ const { Component, computed } = Ember;
 export default Component.extend({
   layout: layout,
   tagName: '',
-  classNameBindings: ['checkboxWrapper'],
-  didReceiveAttrs() {
-    this._super(...arguments);
-    if (this.get('checkboxWrapper')) {
-      this.set('tagName', 'div');
-    } else {
-      this.set('tagName', '');
-    }
-  },
+  label: computed.alias('checkboxComponent.label'),
+  form: computed.alias('checkboxComponent.form'),
+  inputId: computed.alias('checkboxComponent.inputId'),
+  labelClass: computed.alias('checkboxComponent.labelClass'),
+  model: computed.alias('checkboxComponent.model'),
+  property: computed.alias('checkboxComponent.property'),
+  disabled: computed.alias('checkboxComponent.disabled'),
+  required: computed.alias('checkboxComponent.required'),
+  autofocus: computed.alias('checkboxComponent.autofocus'),
+  readonly: computed.alias('checkboxComponent.readonly'),
+  title: computed.alias('checkboxComponent.title'),
+  elementClass: computed.alias('checkboxComponent.elementClass'),
+  name: computed.alias('checkboxComponent.name')
 });

--- a/addon/components/em-checkbox-input.js
+++ b/addon/components/em-checkbox-input.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import layout from '../templates/components/em-checkbox-input';
+
+const { Component, computed } = Ember;
+
+export default Component.extend({
+  layout: layout,
+  tagName: computed('checkboxWrapper', {
+    get() {
+      if (this.get('checkboxWrapper')) {
+        return 'div';
+      }
+
+      return '';
+    }
+  }),
+  classNameBindings: ['checkboxWrapper']
+});

--- a/addon/components/em-checkbox.js
+++ b/addon/components/em-checkbox.js
@@ -16,7 +16,7 @@ export default Component.extend(InputComponentMixin, {
   validations: false,
   labelInControl: true,
 
-  class: computed('form.formLayout', {
+  groupClass: computed('form.formLayout', {
     get() {
       if (this.get('form.formLayout') !== 'horizontal') {
         return 'checkbox';

--- a/addon/components/em-checkbox.js
+++ b/addon/components/em-checkbox.js
@@ -14,7 +14,7 @@ export default Component.extend(InputComponentMixin, {
   layout: layout,
   validationIcons: false,
   validations: false,
-  yieldInLabel: true,
+  labelInControl: true,
 
   class: computed('form.formLayout', {
     get() {
@@ -22,6 +22,16 @@ export default Component.extend(InputComponentMixin, {
         return 'checkbox';
       }
       return 'form-group';
+    }
+  }),
+
+  checkboxWrapper: computed('form.formLayout', {
+    get() {
+      if (this.get('form.formLayout') === 'horizontal') {
+        return 'checkbox';
+      }
+
+      return null;
     }
   })
 });

--- a/addon/components/em-checkbox.js
+++ b/addon/components/em-checkbox.js
@@ -30,7 +30,6 @@ export default Component.extend(InputComponentMixin, {
       if (this.get('form.formLayout') === 'horizontal') {
         return 'checkbox';
       }
-
       return null;
     }
   })

--- a/addon/components/em-form-group.js
+++ b/addon/components/em-form-group.js
@@ -28,9 +28,9 @@ Syntax:
  */
 export default Component.extend(HasPropertyValidationMixin, {
   tagName: 'div',
-  class: 'form-group',
+  groupClass: 'form-group',
   layout: layout,
-  classNameBindings: ['class', 'hasSuccess', 'hasWarning', 'hasError', 'validationIcons:has-feedback', 'required'],
+  classNameBindings: ['groupClass', 'hasSuccess', 'hasWarning', 'hasError', 'validationIcons:has-feedback', 'required'],
   attributeBindings: ['disabled'],
   canShowErrors: false,
   successIcon: 'fa fa-check',

--- a/addon/components/em-form-group.js
+++ b/addon/components/em-form-group.js
@@ -42,6 +42,7 @@ export default Component.extend(HasPropertyValidationMixin, {
 
   inputId: computed.alias('inputComponent.inputId'),
   yieldInLabel: computed.alias('inputComponent.yieldInLabel'),
+  labelInControl: computed.alias('inputComponent.labelInControl'),
   hasError: computed.alias('inputComponent.hasError'),
   hasSuccess: computed.alias('inputComponent.hasSuccess'),
   hasWarning: computed.alias('inputComponent.hasWarning'),

--- a/addon/mixins/input-component.js
+++ b/addon/mixins/input-component.js
@@ -48,11 +48,16 @@ export default Mixin.create(HasPropertyMixin, HasPropertyValidationMixin, HasIdM
     }
   }),
 
-  controlWrapper: computed('form.formLayout', {
+  controlWrapper: computed('form.formLayout', 'labelInControl', {
     get() {
       if (this.get('form.formLayout') === 'horizontal') {
+        if (this.get('labelInControl')) {
+          return 'col-sm-offset-2 col-sm-10';
+        }
+
         return 'col-sm-10';
       }
+
       return null;
     }
   }),

--- a/addon/templates/components/em-checkbox-input.hbs
+++ b/addon/templates/components/em-checkbox-input.hbs
@@ -1,0 +1,13 @@
+{{#em-form-label text=label horiClass='' inlineClass='' form=form for=inputId extraClass=labelClass}}
+    {{input
+      id=inputId
+      type='checkbox'
+      checked=(mut (get model property))
+      disabled=disabled
+      required=required
+      autofocus=autofocus
+      readonly=readonly
+      title=title
+      class=elementClass
+      name=name}}
+{{/em-form-label}}

--- a/addon/templates/components/em-checkbox.hbs
+++ b/addon/templates/components/em-checkbox.hbs
@@ -1,4 +1,4 @@
-{{#em-form-group model=model property=property inputComponent=this}}
+{{#em-form-group model=model property=property inputComponent=this class=class}}
     {{#if checkboxWrapper}}
         <div class={{checkboxWrapper}}>
             {{#em-form-label text=label horiClass='' inlineClass='' form=form for=inputId extraClass=labelClass}}
@@ -30,5 +30,4 @@
               name=name}}
         {{/em-form-label}}
     {{/if}}
-
 {{/em-form-group}}

--- a/addon/templates/components/em-checkbox.hbs
+++ b/addon/templates/components/em-checkbox.hbs
@@ -1,13 +1,34 @@
 {{#em-form-group model=model property=property inputComponent=this}}
-  {{input
-    id=inputId
-    type='checkbox'
-    checked=(mut (get model property))
-    disabled=disabled
-    required=required
-    autofocus=autofocus
-    readonly=readonly
-    title=title
-    class=elementClass
-    name=name}}
+    {{#if checkboxWrapper}}
+        <div class={{checkboxWrapper}}>
+            {{#em-form-label text=label horiClass='' inlineClass='' form=form for=inputId extraClass=labelClass}}
+                {{input
+                  id=inputId
+                  type='checkbox'
+                  checked=(mut (get model property))
+                  disabled=disabled
+                  required=required
+                  autofocus=autofocus
+                  readonly=readonly
+                  title=title
+                  class=elementClass
+                  name=name}}
+            {{/em-form-label}}
+        </div>
+    {{else}}
+        {{#em-form-label text=label horiClass='' inlineClass='' form=form for=inputId extraClass=labelClass}}
+            {{input
+              id=inputId
+              type='checkbox'
+              checked=(mut (get model property))
+              disabled=disabled
+              required=required
+              autofocus=autofocus
+              readonly=readonly
+              title=title
+              class=elementClass
+              name=name}}
+        {{/em-form-label}}
+    {{/if}}
+
 {{/em-form-group}}

--- a/addon/templates/components/em-checkbox.hbs
+++ b/addon/templates/components/em-checkbox.hbs
@@ -1,4 +1,4 @@
-{{#em-form-group model=model property=property inputComponent=this class=class}}
+{{#em-form-group model=model property=property inputComponent=this groupClass=groupClass}}
     {{#if checkboxWrapper}}
         <div class={{checkboxWrapper}}>
             {{em-checkbox-input checkboxComponent=this}}

--- a/addon/templates/components/em-checkbox.hbs
+++ b/addon/templates/components/em-checkbox.hbs
@@ -1,33 +1,17 @@
 {{#em-form-group model=model property=property inputComponent=this class=class}}
-    {{#if checkboxWrapper}}
-        <div class={{checkboxWrapper}}>
-            {{#em-form-label text=label horiClass='' inlineClass='' form=form for=inputId extraClass=labelClass}}
-                {{input
-                  id=inputId
-                  type='checkbox'
-                  checked=(mut (get model property))
-                  disabled=disabled
-                  required=required
-                  autofocus=autofocus
-                  readonly=readonly
-                  title=title
-                  class=elementClass
-                  name=name}}
-            {{/em-form-label}}
-        </div>
-    {{else}}
-        {{#em-form-label text=label horiClass='' inlineClass='' form=form for=inputId extraClass=labelClass}}
-            {{input
-              id=inputId
-              type='checkbox'
-              checked=(mut (get model property))
-              disabled=disabled
-              required=required
-              autofocus=autofocus
-              readonly=readonly
-              title=title
-              class=elementClass
-              name=name}}
-        {{/em-form-label}}
-    {{/if}}
+    {{em-checkbox-input
+        autofocus=autofocus
+        checkboxWrapper=checkboxWrapper
+        disabled=disabled
+        elementClass=elementClass
+        form=form
+        inputId=inputId
+        label=label
+        labelClass=labelClass
+        model=model
+        name=name
+        property=property
+        readonly=readonly
+        required=required
+        title=title}}
 {{/em-form-group}}

--- a/addon/templates/components/em-checkbox.hbs
+++ b/addon/templates/components/em-checkbox.hbs
@@ -1,17 +1,9 @@
 {{#em-form-group model=model property=property inputComponent=this class=class}}
-    {{em-checkbox-input
-        autofocus=autofocus
-        checkboxWrapper=checkboxWrapper
-        disabled=disabled
-        elementClass=elementClass
-        form=form
-        inputId=inputId
-        label=label
-        labelClass=labelClass
-        model=model
-        name=name
-        property=property
-        readonly=readonly
-        required=required
-        title=title}}
+    {{#if checkboxWrapper}}
+        <div class={{checkboxWrapper}}>
+            {{em-checkbox-input checkboxComponent=this}}
+        </div>
+    {{else}}
+        {{em-checkbox-input checkboxComponent=this}}
+    {{/if}}
 {{/em-form-group}}

--- a/addon/templates/components/em-form-group.hbs
+++ b/addon/templates/components/em-form-group.hbs
@@ -1,11 +1,11 @@
 {{#if wrapperClass}}
     <div class={{wrapperClass}}>
-        {{#form-group yieldInLabel=yieldInLabel formComponent=this form=form}}
+        {{#form-group yieldInLabel=yieldInLabel labelInControl=labelInControl formComponent=this form=form}}
             {{yield this}}
         {{/form-group}}
     </div>
 {{else}}
-    {{#form-group yieldInLabel=yieldInLabel formComponent=this form=form}}
+    {{#form-group yieldInLabel=yieldInLabel labelInControl=labelInControl formComponent=this form=form}}
         {{yield this}}
     {{/form-group}}
 {{/if}}

--- a/addon/templates/components/form-group.hbs
+++ b/addon/templates/components/form-group.hbs
@@ -1,5 +1,9 @@
 {{#if formComponent.label}}
-    {{#if yieldInLabel}}
+    {{#if labelInControl}}
+        {{#form-group-control controlWrapper=formComponent.controlWrapper formComponent=formComponent form=form}}
+            {{yield}}
+        {{/form-group-control}}
+    {{else if yieldInLabel}}
         {{#if formComponent.labelWrapperClass}}
             <div class={{formComponent.labelWrapperClass}}>
                 {{#control-within-label label=formComponent.label extraClass=formComponent.labelClass

--- a/app/components/em-checkbox-input.js
+++ b/app/components/em-checkbox-input.js
@@ -1,0 +1,3 @@
+import CheckboxInputComponent from 'ember-rapid-forms/components/em-checkbox-input';
+
+export default CheckboxInputComponent;

--- a/tests/dummy/app/templates/controls/checkbox.hbs
+++ b/tests/dummy/app/templates/controls/checkbox.hbs
@@ -33,5 +33,6 @@ Checkboxes let a user select or deselect an option.
     <tr><td>disabled</td><td>Standard HTML5 disabled attribute.</td><td>null</td></tr>
     <tr><td>required</td><td>Standard HTML5 required attribute.</td><td>null</td></tr>
     <tr><td>autofocus</td><td>Standard HTML5 autofocus attribute.</td><td>null</td></tr>
+    <tr><td>labelInControl</td><td>Whether the label should be rendered inside the control layout (true) or around it (false).</td><td>true</td></tr>
 </table>
 

--- a/tests/integration/components/em-form-checkbox-test.js
+++ b/tests/integration/components/em-form-checkbox-test.js
@@ -59,7 +59,7 @@ test('Checkbox renders with custom css', function(assert) {
   this.render(hbs`{{#em-form as |form|}}{{form.checkbox label='My label' elementClass="col-md-6" controlWrapper="col-md-8" labelClass="col-md-4"}}{{/em-form}}`);
 
   assert.ok(this.$().find('label').hasClass('col-md-4'), 'Label has correct class');
-  assert.ok(this.$().find('label').find('.col-md-8').length, 'Checkbox parent has correct class');
+  assert.ok(this.$().find('label').parent().hasClass('col-md-8'), 'Checkbox parent has correct class');
   assert.ok(this.$().find('input').hasClass('col-md-6'), 'Checkbox input has correct class');
 });
 


### PR DESCRIPTION
Fixes https://github.com/piceaTech/ember-rapid-forms/issues/163.

1. I added a new `labelInControl` flag to indicate that the label is rendered in the control. Seemed to me like the only way to get the label where it needs to be relative to the control in the case of a checkbox. I modified the `input-component` `controlWrapper` property to consider this when determining the bootstrap classes to apply.
2. I didn't remove the `yieldInLabel` handling even though it's not used by anything in this repo anymore, since it could be used by manually rendering a `form-group`.
3. I thought about using `labelWrapperClass` instead of adding `checkboxWrapper`, but then you couldn't use `labelWrapperClass` on a checkbox, so I opted against doing that.
4. I added `class=class` to the `em-checkbox` template, since that should have been present, but wasn't.