### PR TITLE
Add maxlength attribute to em-input component

### DIFF
--- a/addon/components/em-input.js
+++ b/addon/components/em-input.js
@@ -23,6 +23,7 @@ export default Component.extend(InputComponentMixin, {
   autoresize: null,
   disabled: null,
   canShowErrors: false,
+  maxlength:null,
 
   hideValidationsOnFormChange: observer('form', 'form.model', function() {
     this.set('canShowErrors', false);

--- a/addon/templates/components/em-input.hbs
+++ b/addon/templates/components/em-input.hbs
@@ -14,5 +14,6 @@
     autofocus=autofocus
     readonly=readonly
     autoresize=autoresize
+    maxlength=maxlength
   }}
 {{/em-form-group}}


### PR DESCRIPTION
This would add `maxlength` attribute, which would allow limiting maximum characters in input element.