### PR TITLE
Possible fix for rare backtracking re-render issue

### DIFF
--- a/addon/components/em-select.js
+++ b/addon/components/em-select.js
@@ -91,7 +91,7 @@ export default Component.extend(InputComponentMixin, {
 
       let selectedIndex = selectedEl.selectedIndex;
 
-      if (selectedIndex < 0) return;
+      if (selectedIndex < 0 || !this.get('content.length')) return;
 
       // check whether we show prompt the correct to show index is one less
       // when selecting prompt don't change anything


### PR DESCRIPTION
An em-select with a prompt, during its initial (didReceiveAttrs) _setValue call, if the content (options) of the em-select are not yet set but the value of the model's property is not null, the em-select will attempt to set the model's property to null. 
This set operation can cause the backtracking re-render.

The idea with the proposed solution is to cancel the initial _setValue if the content is empty

This may be only one was to cause the issue, and there may be better solutions for it.
This may not even be a problem that is the responsibility of em-select to fix, however my application code doesn't break any conventions I've come across before.

At the very least, I can't see how that addition IF clause will break anything.

Here is a twiddle with an example that is very similar to my project's use case.
In the application controller, the options are retrieved with an AJAX request (through Ember Data), but the selected option is known before the full list of options is retrieved.
We then show the same set of options in two lists, filtering out the selected option of each list from the other.
It's probably not the simplest example, but it was the best I could do in the time I had.
https://ember-twiddle.com/b93baebaabf35d59f79e8e21d7d55d32?openFiles=initializers.ember-rapid-form-fix.js%2C