### PR TITLE
fix: move ember-font-awesome to the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-cli-babel": "^6.6.0"
+    "ember-cli-babel": "^6.6.0",
+    "ember-font-awesome": "~3.0.5"
   },
   "devDependencies": {
     "bootstrap": "^3.3.7",
@@ -49,7 +50,6 @@
     "ember-cli-uglify": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
-    "ember-font-awesome": "~3.0.5",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-truth-helpers": "~1.3.0",


### PR DESCRIPTION
As stated in #179 one needs ember-font-awesome in the app to have the helper `fa-icon`