### PR TITLE
Add focusOut event support for em-input

### DIFF
--- a/addon/components/em-input.js
+++ b/addon/components/em-input.js
@@ -31,10 +31,10 @@ export default Component.extend(InputComponentMixin, {
   actions: {
     /*
     Listen to the focus out of the form group and display the errors
-    Pass this event as emFocusOut
+    Pass this event as focusOut
      */
     focusOut() {
-      this.sendAction('emFocusOut');
+      this.sendAction('focusOut');
       return this.set('canShowErrors', true);
     },
   },

--- a/addon/components/em-input.js
+++ b/addon/components/em-input.js
@@ -28,17 +28,6 @@ export default Component.extend(InputComponentMixin, {
     this.set('canShowErrors', false);
   }),
 
-  actions: {
-    /*
-    Listen to the focus out of the form group and display the errors
-    Pass this event as focusOut
-     */
-    focusOut() {
-      this.sendAction('focusOut');
-      return this.set('canShowErrors', true);
-    },
-  },
-
   /*
   Observes the helpHasErrors of the help control and modify the 'status' property accordingly.
    */

--- a/addon/components/em-input.js
+++ b/addon/components/em-input.js
@@ -23,11 +23,22 @@ export default Component.extend(InputComponentMixin, {
   autoresize: null,
   disabled: null,
   canShowErrors: false,
-  maxlength:null,
+  maxlength: null,
 
   hideValidationsOnFormChange: observer('form', 'form.model', function() {
     this.set('canShowErrors', false);
   }),
+
+  actions: {
+    /*
+    Listen to the focus out of the form group and display the errors
+    Relay action as emFocusOut
+     */
+    focusOut() {
+      this.sendAction('emFocusOut');
+      return this.set('canShowErrors', true);
+    },
+  },
 
   /*
   Observes the helpHasErrors of the help control and modify the 'status' property accordingly.
@@ -36,13 +47,6 @@ export default Component.extend(InputComponentMixin, {
     if (this.get('form.showErrorsOnFocusIn')) {
       return this.set('canShowErrors', true);
     }
-  },
-
-  /*
-  Listen to the focus out of the form group and display the errors
-   */
-  focusOut() {
-    return this.set('canShowErrors', true);
   },
 
   /*

--- a/addon/components/em-input.js
+++ b/addon/components/em-input.js
@@ -31,7 +31,7 @@ export default Component.extend(InputComponentMixin, {
   actions: {
     /*
     Listen to the focus out of the form group and display the errors
-    Relay action as emFocusOut
+    Pass this event as emFocusOut
      */
     focusOut() {
       this.sendAction('emFocusOut');

--- a/addon/mixins/input-component.js
+++ b/addon/mixins/input-component.js
@@ -117,6 +117,7 @@ export default Mixin.create(HasPropertyMixin, HasPropertyValidationMixin, HasIdM
 
   /*
   Listen to the focus out of the form group and display the errors
+  Also bubble-up focusOut event
    */
   focusOut() {
     if (this) {

--- a/addon/mixins/input-component.js
+++ b/addon/mixins/input-component.js
@@ -119,7 +119,9 @@ export default Mixin.create(HasPropertyMixin, HasPropertyValidationMixin, HasIdM
   Listen to the focus out of the form group and display the errors
    */
   focusOut() {
-    return this.set('canShowErrors', true);
+    if (this) {
+      return this.set('canShowErrors', true);
+    }
   },
 
   /*

--- a/addon/mixins/input-component.js
+++ b/addon/mixins/input-component.js
@@ -120,6 +120,7 @@ export default Mixin.create(HasPropertyMixin, HasPropertyValidationMixin, HasIdM
    */
   focusOut() {
     if (this) {
+      this.sendAction('focusOut');
       return this.set('canShowErrors', true);
     }
   },

--- a/addon/templates/components/em-input.hbs
+++ b/addon/templates/components/em-input.hbs
@@ -15,6 +15,6 @@
     readonly=readonly
     autoresize=autoresize
     maxlength=maxlength
-    focusOut=(action 'focusOut')
+    focusOut=(action focusOut)
   }}
 {{/em-form-group}}

--- a/addon/templates/components/em-input.hbs
+++ b/addon/templates/components/em-input.hbs
@@ -15,5 +15,6 @@
     readonly=readonly
     autoresize=autoresize
     maxlength=maxlength
+    focusOut=(action 'focusOut')
   }}
 {{/em-form-group}}

--- a/tests/dummy/app/models/credentials.js
+++ b/tests/dummy/app/models/credentials.js
@@ -1,6 +1,5 @@
 import { not } from '@ember/object/computed';
-import DS from 'ember-data';
-const { Model, attr } = DS;
+import { Model, attr } from 'ember-data';
 import { validator, buildValidations } from 'ember-cp-validations';
 import InputErrors from 'ember-rapid-forms/mixins/input-errors';
 import helper from 'ember-rapid-forms/mixins/ember-cp-validations-helper';

--- a/tests/dummy/app/models/credentials.js
+++ b/tests/dummy/app/models/credentials.js
@@ -1,5 +1,6 @@
 import { not } from '@ember/object/computed';
-import { Model, attr } from 'ember-data';
+import DS from 'ember-data';
+const { Model, attr } = DS;
 import { validator, buildValidations } from 'ember-cp-validations';
 import InputErrors from 'ember-rapid-forms/mixins/input-errors';
 import helper from 'ember-rapid-forms/mixins/ember-cp-validations-helper';

--- a/tests/integration/components/em-input-test.js
+++ b/tests/integration/components/em-input-test.js
@@ -70,13 +70,17 @@ test('Input can be autofocused', function(assert) {
 
 
 test('Input can have emFocusOut event', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   this.set('fruit', EmberObject.create());
+
   this.on('focusOutHandler', function(){
     assert.ok(true);
   });
 
-  this.render(hbs`{{#em-form as |form|}}{{form.input  property="asd" emFocusOut='focusOutHandler'}}{{/em-form}}`);
+  this.render(hbs`{{#em-form as |form|}}{{form.input property="asd" model=fruit emFocusOut='focusOutHandler'}}{{/em-form}}`);
+
+  assert.ok(this.$().find('input'), 'input has emFocusOut');
+
   this.$().find('input').click().blur();
 });

--- a/tests/integration/components/em-input-test.js
+++ b/tests/integration/components/em-input-test.js
@@ -69,7 +69,7 @@ test('Input can be autofocused', function(assert) {
 });
 
 
-test('Input can have emFocusOut event', function(assert) {
+test('Input can have focusOut event', function(assert) {
   assert.expect(2);
 
   this.set('fruit', EmberObject.create());
@@ -78,9 +78,9 @@ test('Input can have emFocusOut event', function(assert) {
     assert.ok(true);
   });
 
-  this.render(hbs`{{#em-form as |form|}}{{form.input property="asd" model=fruit emFocusOut='focusOutHandler'}}{{/em-form}}`);
+  this.render(hbs`{{#em-form as |form|}}{{form.input property="asd" model=fruit focusOut='focusOutHandler'}}{{/em-form}}`);
 
-  assert.ok(this.$().find('input'), 'input has emFocusOut');
+  assert.ok(this.$().find('input'), 'input has focusOut');
 
   this.$().find('input').click().blur();
 });

--- a/tests/integration/components/em-input-test.js
+++ b/tests/integration/components/em-input-test.js
@@ -73,11 +73,9 @@ test('Input can have emFocusOut event', function(assert) {
   assert.expect(1);
 
   this.set('fruit', Ember.Object.create());
-  const focusOutHandler = () => {
+  this.on('focusOutHandler', function(){
     assert.ok(true);
-  }
-  this.on('focusOutHandler', focusOutHandler);
-  this.set('focusOutHandler', focusOutHandler);
+  });
 
   this.render(hbs`{{#em-form as |form|}}{{form.input model=fruit emFocusOut='focusOutHandler'}}{{/em-form}}`);
   this.$().find('input').click().blur();

--- a/tests/integration/components/em-input-test.js
+++ b/tests/integration/components/em-input-test.js
@@ -72,7 +72,7 @@ test('Input can be autofocused', function(assert) {
 test('Input can have emFocusOut event', function(assert) {
   assert.expect(1);
 
-  this.set('fruit', Ember.Object.create());
+  this.set('fruit', EmberObject.create());
   this.on('focusOutHandler', function(){
     assert.ok(true);
   });

--- a/tests/integration/components/em-input-test.js
+++ b/tests/integration/components/em-input-test.js
@@ -67,3 +67,16 @@ test('Input can be autofocused', function(assert) {
 
   assert.ok(this.$().find('input'), 'input has autofocus');
 });
+
+
+test('Input can have focus-out event', function(assert) {
+  assert.expect(1);
+
+  this.set('fruit', Ember.Object.create());
+  this.on('focusOutHandler', function(){
+    assert.ok(true);
+  });
+
+  this.render(hbs`{{#em-form as |form|}}{{form.input model=fruit emFocusOut='focusOutHandler'}}{{/em-form}}`);
+  this.$().find('input').click().blur();
+});

--- a/tests/integration/components/em-input-test.js
+++ b/tests/integration/components/em-input-test.js
@@ -73,9 +73,11 @@ test('Input can have emFocusOut event', function(assert) {
   assert.expect(1);
 
   this.set('fruit', Ember.Object.create());
-  this.on('focusOutHandler', function(){
+  const focusOutHandler = () => {
     assert.ok(true);
-  });
+  }
+  this.on('focusOutHandler', focusOutHandler);
+  this.set('focusOutHandler', focusOutHandler);
 
   this.render(hbs`{{#em-form as |form|}}{{form.input model=fruit emFocusOut='focusOutHandler'}}{{/em-form}}`);
   this.$().find('input').click().blur();

--- a/tests/integration/components/em-input-test.js
+++ b/tests/integration/components/em-input-test.js
@@ -70,15 +70,15 @@ test('Input can be autofocused', function(assert) {
 
 
 test('Input can have focusOut event', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   this.set('fruit', EmberObject.create());
 
-  this.on('focusOutHandler', function(){
+  this.set('focusOutHandler', function(){
     assert.ok(true);
   });
 
-  this.render(hbs`{{#em-form as |form|}}{{form.input property="asd" model=fruit focusOut='focusOutHandler'}}{{/em-form}}`);
+  this.render(hbs`{{#em-form as |form|}}{{form.input property="asd" model=fruit focusOut=focusOutHandler}}{{/em-form}}`);
 
   assert.ok(this.$().find('input'), 'input has focusOut');
 

--- a/tests/integration/components/em-input-test.js
+++ b/tests/integration/components/em-input-test.js
@@ -77,6 +77,6 @@ test('Input can have emFocusOut event', function(assert) {
     assert.ok(true);
   });
 
-  this.render(hbs`{{#em-form as |form|}}{{form.input model=fruit emFocusOut='focusOutHandler'}}{{/em-form}}`);
+  this.render(hbs`{{#em-form as |form|}}{{form.input  property="asd" emFocusOut='focusOutHandler'}}{{/em-form}}`);
   this.$().find('input').click().blur();
 });

--- a/tests/integration/components/em-input-test.js
+++ b/tests/integration/components/em-input-test.js
@@ -69,7 +69,7 @@ test('Input can be autofocused', function(assert) {
 });
 
 
-test('Input can have focus-out event', function(assert) {
+test('Input can have emFocusOut event', function(assert) {
   assert.expect(1);
 
   this.set('fruit', Ember.Object.create());


### PR DESCRIPTION
Currently em-input doesn't have focusOut event. Added support for `focusOut` event.
  
  