### PR TITLE
assigning computed properties is deprecated

### DIFF
--- a/addon/components/em-select.js
+++ b/addon/components/em-select.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed, get } from '@ember/object';
+import { computed, get, defineProperty } from '@ember/object';
 import { run } from '@ember/runloop';
 import layout from '../templates/components/em-select';
 import InputComponentMixin from '../mixins/input-component';
@@ -76,7 +76,7 @@ export default Component.extend(InputComponentMixin, {
     }
 
     // set it to the correct value of the selection
-    this.selectedValue = computed('model.' + this.get('property'), function() {
+    defineProperty(this, 'selectedValue', computed('model.' + this.get('property'), function() {
       const propertyIsModel = this.get('propertyIsModel');
       let value = this.get('model.' + this.get('property'));
       if(propertyIsModel && value !== null && value !== undefined) {
@@ -88,7 +88,7 @@ export default Component.extend(InputComponentMixin, {
         }
       }
       return value;
-    });
+    }));
   },
 
   _setValue() {


### PR DESCRIPTION
Assigning a CP is deprecated in 3.2 and, although it shouldn't, it  is causing exceptions in my code:
```TypeError: Cannot set property selectedValue of [object Object] which has only a getter```.

This should get rid of it. I haven't checked thoroughfully if there are similar assignments in the code.