### PR TITLE
Use `run` instead of `run.schedule 'sync'` in em-select

### DIFF
--- a/addon/components/em-select.js
+++ b/addon/components/em-select.js
@@ -38,7 +38,7 @@ export default Component.extend(InputComponentMixin, {
   didInsertElement() {
     this._super(...arguments);
 
-    run.schedule('sync', this, () => {
+    run(this, () => {
       if(this.get('model.isLoading')) {
         this.get('model').on('didLoad', () => {
           this._setValue();


### PR DESCRIPTION
Closes https://github.com/piceaTech/ember-rapid-forms/issues/189
Re-implementation of https://github.com/piceaTech/ember-rapid-forms/pull/190 since that PR isn't being updated