### PR TITLE
Fix `run` deprecation, drop 2.8 LTS, add 2.18 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "9"
+  - "8"
 
 sudo: required
 dist: trusty
@@ -21,8 +21,8 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.8
     - EMBER_TRY_SCENARIO=ember-lts-2.12
+    - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary

--- a/addon/components/em-select.js
+++ b/addon/components/em-select.js
@@ -38,7 +38,7 @@ export default Component.extend(InputComponentMixin, {
   didInsertElement() {
     this._super(...arguments);
 
-    run.schedule('sync', this, () => {
+    run(this, () => {
       if(this.get('model.isLoading')) {
         this.get('model').on('didLoad', () => {
           this._setValue();

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,13 +3,13 @@ module.exports = {
   useYarn: true,
   scenarios: [
     {
-      name: 'ember-lts-2.8',
+      name: 'ember-lts-2.12',
       bower: {
         dependencies: {
-          'ember': 'components/ember#lts-2-8'
+          'ember': 'components/ember#2.12.2'
         },
         resolutions: {
-          'ember': 'lts-2-8'
+          'ember': '2.12.2'
         }
       },
       npm: {
@@ -18,14 +18,14 @@ module.exports = {
         }
       }
     },
-    {
-      name: 'ember-lts-2.12',
+        {
+      name: 'ember-lts-2.18',
       bower: {
         dependencies: {
-          'ember': 'components/ember#2.12.2'
+          'ember': 'components/ember#2.18.2'
         },
         resolutions: {
-          'ember': '2.12.2'
+          'ember': '2.18.2'
         }
       },
       npm: {


### PR DESCRIPTION
Closes #189
Re-implementation of #190 since that PR isn't being updated

Based on changes requested here #198. PR got closed accidentally while squashing commits.