### PR TITLE
Bug fix: make multiple selects work properly

### DIFF
--- a/addon/components/em-select.js
+++ b/addon/components/em-select.js
@@ -77,21 +77,44 @@ export default Component.extend(InputComponentMixin, {
 
     // set it to the correct value of the selection
     defineProperty(this, 'selectedValue', computed('model.' + this.get('property'), function() {
-      const propertyIsModel = this.get('propertyIsModel');
-      let value = this.get('model.' + this.get('property'));
-      if(propertyIsModel && value !== null && value !== undefined) {
-        const optionValuePath = this.get('optionValuePath');
-        if(value.get === undefined) {
-          value = value[optionValuePath];
+      if (this.get("multiple")) {
+        const values = this.get('model.' + this.get('property'));
+
+        if (values && values.map) {
+          return values.map((value) => {
+            return this._getValue(value);
+          });
         } else {
-          value = value.get(optionValuePath);
+          return [];
         }
+      } else {
+        return this._getValue(this.get('model.' + this.get('property')));
       }
-      return value;
     }));
   },
 
+  _getValue(value) {
+    const propertyIsModel = this.get('propertyIsModel');
+    if(propertyIsModel && value !== null && value !== undefined) {
+      const optionValuePath = this.get('optionValuePath');
+      if(value.get === undefined) {
+        value = value[optionValuePath];
+      } else {
+        value = value.get(optionValuePath);
+      }
+    }
+    return value;
+  },
+
   _setValue() {
+    if (this.get("multiple")) {
+      this._setValueMultiple();
+    } else {
+      this._setValueSingle();
+    }
+  },
+
+  _setValueSingle() {
     const selectedEl = this.$('select')[0];
     const model = this.get('model');
     if (model) {
@@ -144,6 +167,80 @@ export default Component.extend(InputComponentMixin, {
       }
 
       model.set(this.get('property'), selectedID);
+    }
+  },
+  _setValueMultiple() {
+    const selectedEl = this.$('select')[0];
+    const model = this.get('model');
+    if (model) {
+
+      let selectedIndices = [];
+
+      // el.selectedOptions is not supported in IE.
+      for (let index = 0; index < selectedEl.options.length; index++) {
+        if (selectedEl.options[index].selected) {
+          selectedIndices.push(index);
+        }
+      }
+
+      if (selectedIndices.length === 0 || !this.get('content.length')) return;
+
+      // check whether we show prompt the correct to show index is one less
+      // if we select prompt, remove it. If we're empty, then step model to empty array.
+      if(this.get('prompt')){
+        const promptIndex = Array.prototype.indexOf.call(selectedIndices, 0);
+        if(promptIndex > -1){
+          selectedIndices.splice(promptIndex, 1);
+        }
+
+        if (selectedIndices.length === 0) {
+          model.set(this.get('property'), []);
+        }
+        return;
+      }
+
+      let selectedValues = [];
+
+      if(this.get('optionGroupContentPath')){
+        selectedValues = selectedIndices.flatMap((selectedIndex) => {
+          const selectedElement = selectedEl.options[selectedIndex + 1];
+          const optGroup = selectedElement.parentNode;
+          const optGroupOptions = optGroup.children;
+          const positionInOptGroup = Array.prototype.indexOf.call(optGroupOptions, selectedElement);
+          const optionGroup = this.get('content').filterBy(this.get('optionGroupLabelPath'), optGroup.label)[0];
+
+          const selectedValue = get(optionGroup, this.get('optionGroupContentPath')).objectAt(positionInOptGroup);
+
+          if (this.get('optionDisabledPath') && get(selectedValue, this.get('optionDisabledPath'))) {
+            // remove this item if it is disabled
+            return [];
+          } else {
+            return [selectedValue];
+          }
+        });
+      }
+      else{
+        const content = this.get('content');
+
+        selectedValues = selectedIndices.map((selectedIndex) => {
+          return content.objectAt(selectedIndex);
+        })
+      }
+
+      const optionValuePath = this.get('optionValuePath');
+      const propertyIsModel = this.get('propertyIsModel');
+
+      let finalSelection;
+
+      if(propertyIsModel) {
+        finalSelection = selectedValues;
+      } else {
+        finalSelection = selectedValues.map((value) => {
+          return value[optionValuePath];
+        });
+      }
+
+      model.set(this.get('property'), finalSelection);
     }
   }
 });

--- a/addon/templates/components/em-select.hbs
+++ b/addon/templates/components/em-select.hbs
@@ -19,7 +19,7 @@
       {{/each}}
     {{else}}
       {{#each content key="@index" as |item|}}
-        <option value="{{get item optionValuePath}}" selected={{eq (get item optionValuePath) selectedValue}} disabled={{get item optionDisabledPath}}>
+        <option value="{{get item optionValuePath}}" selected={{if multiple (contains (get item optionValuePath) selectedValue) (eq (get item optionValuePath) selectedValue)}} disabled={{get item optionDisabledPath}}>
         {{get item optionLabelPath}}
         </option>
       {{/each}}

--- a/package.json
+++ b/package.json
@@ -45,18 +45,19 @@
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-uglify": "^2.0.0",
+    "ember-composable-helpers": "^2.1.0",
     "ember-cp-validations": "~3.3.2",
     "ember-data": "^2.11.1",
-    "ember-cli-uglify": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
+    "ember-source": "~2.16.0",
     "ember-truth-helpers": "~1.3.0",
     "eslint-plugin-ember": "^3.0.1",
     "loader.js": "^4.2.3",
-    "standard-version": "^4.2.0",
-    "ember-source": "~2.16.0"
+    "standard-version": "^4.2.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/tests/integration/components/em-select-test.js
+++ b/tests/integration/components/em-select-test.js
@@ -309,3 +309,63 @@ test('Triggers the action', function(assert) {
     this.$(select).trigger('change');
   });
 });
+
+test('em-select renders with all multiple items selected', function(assert) {
+  fruitSalad.set('fruits', [3, 4])
+
+  this.set('fruitOptions', fruitOptions);
+  this.set('fruitSalad', fruitSalad);
+
+  this.render(hbs`{{#em-form as |form|}}{{form.select multiple=true label="Fruits:" content=fruitOptions optionValuePath='id' optionLabelPath='name' property='fruits' model=fruitSalad}}{{/em-form}}`);
+
+  const element = this.$();
+  assert.equal(element.find('label:contains("Fruits:")').length, 1, 'label has for property');
+
+  const select = element.find('select')[0];
+  assert.equal(select.options.length, 5, 'select has correct amount of options');
+  assert.deepEqual($(select).val(), ['3', '4'])
+
+});
+
+test('em-select can select multiple items', function(assert) {
+
+  this.set('fruitOptions', fruitOptions);
+  this.set('fruitSalad', fruitSalad);
+
+  this.render(hbs`{{#em-form as |form|}}{{form.select multiple=true label="Fruits:" content=fruitOptions optionValuePath='id' optionLabelPath='name' property='favoriteFruit' model=fruitSalad}}{{/em-form}}`);
+
+  const element = this.$();
+  assert.equal(element.find('label:contains("Fruits:")').length, 1, 'label has for property');
+
+  const select = element.find('select')[0];
+  assert.equal(select.options.length, 5, 'select has correct amount of options');
+
+  run(() => {
+    this.$(select).val(['3', '4']);
+    this.$(select).trigger('change');
+  });
+
+  assert.deepEqual(fruitSalad.get('favoriteFruit'), [3, 4], 'model favorite fruit is the selection');
+
+});
+
+test('em-select uses array for single item in multiple mode', function(assert) {
+
+  this.set('fruitOptions', fruitOptions);
+  this.set('fruitSalad', fruitSalad);
+
+  this.render(hbs`{{#em-form as |form|}}{{form.select multiple=true label="Fruits:" content=fruitOptions optionValuePath='id' optionLabelPath='name' property='favoriteFruit' model=fruitSalad}}{{/em-form}}`);
+
+  const element = this.$();
+  assert.equal(element.find('label:contains("Fruits:")').length, 1, 'label has for property');
+
+  const select = element.find('select')[0];
+  assert.equal(select.options.length, 5, 'select has correct amount of options');
+
+  run(() => {
+    this.$(select).val('3');
+    this.$(select).trigger('change');
+  });
+  assert.deepEqual(fruitSalad.get('favoriteFruit'), [3], 'model favorite fruit is the selection');
+
+});


### PR DESCRIPTION
I noticed that there is no actual code to make multiple selects operate correctly. This is a fairly quick fix to address that.

Unfortunately, it has caused a fair amount of additional complexity:
 * Addition of `ember-composable-helpers` to make the `selected` property on the option work.
 * Quite of lot of extra code on the component.

Please consider this a starting point, I'm happy to throw this out/make changes if there's a better way. Thanks for the addon!